### PR TITLE
Fix NameError: 'token_update' not defined in Rootly token validation

### DIFF
--- a/backend/app/api/endpoints/rootly.py
+++ b/backend/app/api/endpoints/rootly.py
@@ -77,7 +77,7 @@ async def test_rootly_token_preview(
     # Check if user already has this exact token (only active integrations)
     existing_token = db.query(RootlyIntegration).filter(
         RootlyIntegration.user_id == current_user.id,
-        RootlyIntegration.api_token == token_update.token,
+        RootlyIntegration.api_token == token_request.token,
         RootlyIntegration.is_active == True
     ).first()
     


### PR DESCRIPTION
- Change token_update.token to token_request.token in test_rootly_token_preview()
- Fixes security middleware error when adding new Rootly tokens
- Parameter name mismatch between function signature and usage