### PR TITLE
Refactor: Extract integrations page into modular components

### DIFF
--- a/frontend/src/app/integrations/components/GitHubConnectedCard.tsx
+++ b/frontend/src/app/integrations/components/GitHubConnectedCard.tsx
@@ -1,0 +1,155 @@
+import Image from "next/image"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Key, Calendar, Building, Clock, Users, TestTube, Trash2, Loader2, CheckCircle } from "lucide-react"
+import { GitHubIntegration } from "../types"
+
+interface GitHubConnectedCardProps {
+  integration: GitHubIntegration
+  onDisconnect: () => void
+  onTest: () => void
+  onViewMappings: () => void
+  loadingMappings: boolean
+  selectedMappingPlatform: string | null
+}
+
+export function GitHubConnectedCard({
+  integration,
+  onDisconnect,
+  onTest,
+  onViewMappings,
+  loadingMappings,
+  selectedMappingPlatform
+}: GitHubConnectedCardProps) {
+  return (
+    <Card className="border-green-200 bg-green-50 max-w-2xl mx-auto">
+      <CardHeader className="p-8">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center space-x-3">
+            <div className="w-10 h-10 rounded-lg flex items-center justify-center">
+              <Image
+                src="/images/github-logo.png"
+                alt="GitHub"
+                width={40}
+                height={40}
+                className="h-10 w-10 object-contain"
+              />
+            </div>
+            <div>
+              <CardTitle>GitHub Connected</CardTitle>
+              <div className="space-y-1 text-sm text-muted-foreground">
+                <div>Username: {integration.github_username}</div>
+                {!integration.is_beta && (
+                  <div>Token: {integration.token_preview}</div>
+                )}
+              </div>
+            </div>
+          </div>
+          <div className="flex items-center space-x-2">
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={onViewMappings}
+              disabled={loadingMappings}
+              className="bg-blue-50 text-blue-700 border-blue-200 hover:bg-blue-100 hover:text-blue-800 hover:border-blue-300"
+              title="View and manage GitHub user mappings"
+            >
+              {loadingMappings && selectedMappingPlatform === 'github' ? (
+                <>
+                  <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                  Loading...
+                </>
+              ) : (
+                <>
+                  <Users className="w-4 h-4 mr-2" />
+                  View Mappings
+                </>
+              )}
+            </Button>
+            {integration.is_beta ? (
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={onTest}
+              >
+                <TestTube className="w-4 h-4 mr-1" />
+                Test Connection
+              </Button>
+            ) : (
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={onDisconnect}
+                className="h-8 w-8 p-0 text-red-600 hover:text-red-700 hover:bg-red-50"
+              >
+                <Trash2 className="w-4 h-4" />
+              </Button>
+            )}
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="p-8 pt-0">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
+          <div className="flex items-center space-x-2">
+            <Key className="w-4 h-4 text-gray-400" />
+            <div>
+              <div className="font-medium">Token Source</div>
+              <div className="text-gray-600">
+                {integration.is_beta
+                  ? "Beta"
+                  : integration.token_source === "oauth"
+                    ? "OAuth"
+                    : "Personal Access Token"
+                }
+              </div>
+            </div>
+          </div>
+          <div className="flex items-center space-x-2">
+            <Calendar className="w-4 h-4 text-gray-400" />
+            <div>
+              <div className="font-medium">Connected</div>
+              <div className="text-gray-600">{new Date(integration.connected_at).toLocaleDateString()}</div>
+            </div>
+          </div>
+          <div className="flex items-center space-x-2">
+            <Building className="w-4 h-4 text-gray-400" />
+            <div>
+              <div className="font-medium">Organizations</div>
+              <div className="text-gray-600">
+                {integration.organizations && integration.organizations.length > 0
+                  ? integration.organizations.join(', ')
+                  : 'None'}
+              </div>
+            </div>
+          </div>
+          <div className="flex items-center space-x-2">
+            <Clock className="w-4 h-4 text-gray-400" />
+            <div>
+              <div className="font-medium">Last Updated</div>
+              <div className="text-gray-600">{new Date(integration.last_updated).toLocaleDateString()}</div>
+            </div>
+          </div>
+        </div>
+
+        {/* Beta Access Information */}
+        {integration.is_beta && (
+          <div className="mt-4 p-4 bg-blue-50 rounded-lg border border-blue-200">
+            <div className="flex items-start space-x-2">
+              <div className="w-5 h-5 text-blue-600 mt-0.5">
+                <CheckCircle className="w-5 h-5" />
+              </div>
+              <div className="flex-1 text-sm">
+                <div className="font-medium text-blue-800 mb-1">Beta Access Enabled</div>
+                <div className="text-blue-700">
+                  You're using a shared GitHub integration for testing purposes.
+                  No personal token setup required.
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/app/integrations/components/GitHubIntegrationCard.tsx
+++ b/frontend/src/app/integrations/components/GitHubIntegrationCard.tsx
@@ -1,0 +1,149 @@
+import { useState } from "react"
+import Image from "next/image"
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
+import { Alert, AlertDescription } from "@/components/ui/alert"
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+import { HelpCircle, ChevronDown, ExternalLink, Eye, EyeOff, Loader2 } from "lucide-react"
+
+interface GitHubIntegrationCardProps {
+  onConnect: (token: string) => Promise<void>
+  isConnecting: boolean
+}
+
+export function GitHubIntegrationCard({ onConnect, isConnecting }: GitHubIntegrationCardProps) {
+  const [showInstructions, setShowInstructions] = useState(false)
+  const [token, setToken] = useState("")
+  const [showToken, setShowToken] = useState(false)
+
+  return (
+    <Card className="border-gray-200 max-w-2xl mx-auto">
+      <CardHeader className="p-8">
+        <div className="flex items-center space-x-3">
+          <div className="w-10 h-10 rounded-lg flex items-center justify-center">
+            <Image
+              src="/images/github-logo.png"
+              alt="GitHub"
+              width={40}
+              height={40}
+              className="h-10 w-10 object-contain"
+            />
+          </div>
+          <div>
+            <CardTitle>Add GitHub Integration</CardTitle>
+            <CardDescription>Connect your GitHub account to analyze development patterns</CardDescription>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4 p-8 pt-0">
+        {/* Instructions */}
+        <div>
+          <button
+            type="button"
+            onClick={() => setShowInstructions(!showInstructions)}
+            className="flex items-center space-x-2 text-sm text-gray-600 hover:text-gray-700"
+          >
+            <HelpCircle className="w-4 h-4" />
+            <span>How to get your GitHub Personal Access Token</span>
+            <ChevronDown className={`w-4 h-4 transition-transform ${showInstructions ? 'rotate-180' : ''}`} />
+          </button>
+          {showInstructions && (
+            <div className="mt-4">
+              <Alert className="border-gray-200 bg-gray-50">
+                <AlertDescription>
+                  <div className="space-y-4">
+                    <div>
+                      <h4 className="font-medium text-gray-900 mb-2"><strong>Step 1:</strong> Go to GitHub Settings</h4>
+                      <p className="text-sm text-gray-600 mb-2">
+                        Navigate to <strong>GitHub → Settings → Developer settings → Personal access tokens → Tokens (classic)</strong>
+                      </p>
+                      <a
+                        href="https://github.com/settings/tokens"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center text-sm text-blue-600 hover:underline"
+                      >
+                        Open GitHub Settings <ExternalLink className="w-3 h-3 ml-1" />
+                      </a>
+                    </div>
+
+                    <div>
+                      <h4 className="font-medium text-gray-900 mb-2"><strong>Step 2:</strong> Generate New Token</h4>
+                      <p className="text-sm text-gray-600 mb-2">Click <strong>"Generate new token (classic)"</strong> and configure:</p>
+                      <ul className="text-sm text-gray-600 space-y-1 ml-4">
+                        <li>• <strong>Note:</strong> Give it a descriptive name (e.g., "Burnout Detector")</li>
+                        <li>• <strong>Expiration:</strong> Set an appropriate expiration date</li>
+                      </ul>
+                    </div>
+
+                    <div>
+                      <h4 className="font-medium text-gray-900 mb-2"><strong>Step 3:</strong> Select Required Scopes</h4>
+                      <p className="text-sm text-gray-600 mb-2">Select these <strong>permissions:</strong></p>
+                      <ul className="text-sm text-gray-600 space-y-1 ml-4">
+                        <li>• <code className="bg-gray-200 px-1 rounded">repo</code> - Full repository access</li>
+                        <li>• <code className="bg-gray-200 px-1 rounded">read:user</code> - Read user profile information</li>
+                        <li>• <code className="bg-gray-200 px-1 rounded">read:org</code> - Read organization membership</li>
+                      </ul>
+                    </div>
+
+                    <div>
+                      <h4 className="font-medium text-gray-900 mb-2"><strong>Step 4:</strong> Generate and Copy Token</h4>
+                      <p className="text-sm text-gray-600">
+                        Click <strong>"Generate token"</strong> and immediately copy the token (starts with <code className="bg-gray-200 px-1 rounded">ghp_</code>).
+                        <strong>You won't be able to see it again!</strong>
+                      </p>
+                    </div>
+                  </div>
+                </AlertDescription>
+              </Alert>
+            </div>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          <label htmlFor="github-token" className="text-sm font-medium">GitHub Personal Access Token</label>
+          <div className="relative">
+            <Input
+              id="github-token"
+              type={showToken ? "text" : "password"}
+              placeholder="ghp_xxxxxxxxxxxxxxxxxxxx"
+              className="pr-10"
+              value={token}
+              onChange={(e) => setToken(e.target.value)}
+            />
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
+              onClick={() => setShowToken(!showToken)}
+            >
+              {showToken ? (
+                <EyeOff className="h-4 w-4 text-gray-400" />
+              ) : (
+                <Eye className="h-4 w-4 text-gray-400" />
+              )}
+            </Button>
+          </div>
+          <p className="text-sm text-gray-500">
+            Token should start with "ghp_" followed by 36 characters
+          </p>
+        </div>
+        <Button
+          className="bg-gray-900 hover:bg-gray-800 text-white"
+          onClick={() => token && onConnect(token)}
+          disabled={!token || isConnecting}
+        >
+          {isConnecting ? (
+            <>
+              <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+              Connecting...
+            </>
+          ) : (
+            'Connect GitHub'
+          )}
+        </Button>
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/app/integrations/components/PagerDutyIntegrationForm.tsx
+++ b/frontend/src/app/integrations/components/PagerDutyIntegrationForm.tsx
@@ -1,0 +1,241 @@
+import { useState } from "react"
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
+import { Alert, AlertDescription } from "@/components/ui/alert"
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form"
+import { HelpCircle, ChevronDown, CheckCircle, AlertCircle, Shield, Plus, Loader2, Eye, EyeOff, Copy, Check } from "lucide-react"
+import { UseFormReturn } from "react-hook-form"
+import { PagerDutyFormData, PreviewData } from "../types"
+
+interface PagerDutyIntegrationFormProps {
+  form: UseFormReturn<PagerDutyFormData>
+  onTest: (platform: 'pagerduty', token: string) => Promise<void>
+  onAdd: () => void
+  connectionStatus: 'idle' | 'success' | 'error' | 'duplicate'
+  previewData: PreviewData | null
+  duplicateInfo: any
+  isTestingConnection: boolean
+  isAdding: boolean
+  isValidToken: (token: string) => boolean
+  onCopyToken: (token: string) => void
+  copied: boolean
+}
+
+export function PagerDutyIntegrationForm({
+  form,
+  onTest,
+  onAdd,
+  connectionStatus,
+  previewData,
+  duplicateInfo,
+  isTestingConnection,
+  isAdding,
+  isValidToken,
+  onCopyToken,
+  copied
+}: PagerDutyIntegrationFormProps) {
+  const [showInstructions, setShowInstructions] = useState(false)
+  const [showToken, setShowToken] = useState(false)
+
+  return (
+    <Card className="border-green-200 max-w-2xl mx-auto">
+      <CardHeader className="p-8">
+        <div className="flex items-center space-x-3">
+          <div className="w-10 h-10 bg-green-100 rounded-lg flex items-center justify-center">
+            <span className="text-green-600 font-bold">PD</span>
+          </div>
+          <div>
+            <CardTitle>Add PagerDuty Integration</CardTitle>
+            <CardDescription>Connect your PagerDuty account for burnout analysis</CardDescription>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4 p-8 pt-0">
+        {/* Instructions */}
+        <div>
+          <button
+            type="button"
+            onClick={() => setShowInstructions(!showInstructions)}
+            className="flex items-center space-x-2 text-sm text-green-600 hover:text-green-700"
+          >
+            <HelpCircle className="w-4 h-4" />
+            <span>How to get your PagerDuty API token</span>
+            <ChevronDown className={`w-4 h-4 transition-transform ${showInstructions ? 'rotate-180' : ''}`} />
+          </button>
+          {showInstructions && (
+            <div className="mt-4">
+              <Alert className="border-green-200 bg-green-50">
+                <AlertDescription>
+                  <ol className="space-y-2 text-sm">
+                    <li><strong>1.</strong> In your PagerDuty account, click on <strong>Integrations</strong> in the top navigation</li>
+                    <li><strong>2.</strong> Look for <strong>API Access Keys</strong> in the dropdown menu</li>
+                    <li><strong>3.</strong> Click <code className="bg-green-100 px-1 rounded">Create API User Token</code> (NOT "Create API Key" - must be user-level)</li>
+                    <li><strong>4.</strong> Give it a description (e.g., <strong>"Burnout Detector"</strong>) and click <strong>Create</strong></li>
+                    <li><strong>5.</strong> Copy the generated token (starts with letters/numbers like <strong>"u+..."</strong>)</li>
+                  </ol>
+                </AlertDescription>
+              </Alert>
+            </div>
+          )}
+        </div>
+
+        {/* Form */}
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit((data) => onTest('pagerduty', data.pagerdutyToken))} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="pagerdutyToken"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>PagerDuty API Token</FormLabel>
+                  <FormControl>
+                    <div className="relative">
+                      <Input
+                        {...field}
+                        type={showToken ? "text" : "password"}
+                        placeholder="Enter your PagerDuty API token"
+                        className="pr-20"
+                      />
+                      <div className="absolute inset-y-0 right-0 flex items-center space-x-1 pr-3">
+                        {field.value && (
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            className="h-7 w-7 p-0"
+                            onClick={() => onCopyToken(field.value)}
+                          >
+                            {copied ? (
+                              <Check className="h-3 w-3 text-green-600" />
+                            ) : (
+                              <Copy className="h-3 w-3 text-slate-400" />
+                            )}
+                          </Button>
+                        )}
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          className="h-7 w-7 p-0"
+                          onClick={() => setShowToken(!showToken)}
+                        >
+                          {showToken ? (
+                            <EyeOff className="h-3 w-3 text-slate-400" />
+                          ) : (
+                            <Eye className="h-3 w-3 text-slate-400" />
+                          )}
+                        </Button>
+                      </div>
+                    </div>
+                  </FormControl>
+                  <FormDescription>
+                    Your API token should be 20-32 characters long
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* Connection Status */}
+            {connectionStatus === 'success' && previewData && (
+              <>
+                <Alert className="border-green-200 bg-green-50">
+                  <CheckCircle className="h-4 w-4 text-green-600" />
+                  <AlertDescription className="text-green-800">
+                    <div className="space-y-2">
+                      <p className="font-semibold">✅ Token validated!</p>
+                      <p className="text-sm text-green-700">Ready to add this PagerDuty integration to your dashboard.</p>
+                      <div className="space-y-1 text-sm">
+                        <p><span className="font-medium">Organization:</span> {previewData.organization_name}</p>
+                        <p><span className="font-medium">Users:</span> {previewData.total_users}</p>
+                      </div>
+                    </div>
+                  </AlertDescription>
+                </Alert>
+
+                <FormField
+                  control={form.control}
+                  name="nickname"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Integration Name (optional)</FormLabel>
+                      <FormControl>
+                        <Input
+                          {...field}
+                          placeholder={previewData.suggested_name || previewData.organization_name}
+                        />
+                      </FormControl>
+                      <FormDescription>
+                        Give this integration a custom name
+                      </FormDescription>
+                    </FormItem>
+                  )}
+                />
+              </>
+            )}
+
+            {connectionStatus === 'error' && (
+              <Alert variant="destructive">
+                <AlertCircle className="h-4 w-4" />
+                <AlertDescription>
+                  ❌ Invalid API token. Please verify your PagerDuty token and try again.
+                </AlertDescription>
+              </Alert>
+            )}
+
+            {connectionStatus === 'duplicate' && duplicateInfo && (
+              <Alert className="border-yellow-200 bg-yellow-50">
+                <AlertCircle className="h-4 w-4 text-yellow-600" />
+                <AlertDescription className="text-yellow-800">
+                  This PagerDuty account is already connected as "{duplicateInfo.existing_integration?.name || 'Unknown'}".
+                </AlertDescription>
+              </Alert>
+            )}
+
+            <div className="flex space-x-3">
+              <Button
+                type="submit"
+                disabled={isTestingConnection || !isValidToken(form.watch('pagerdutyToken') || '')}
+                className="bg-green-600 hover:bg-green-700"
+              >
+                {isTestingConnection ? (
+                  <>
+                    <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                    Testing Connection...
+                  </>
+                ) : (
+                  <>
+                    <Shield className="w-4 h-4 mr-2" />
+                    Test Connection
+                  </>
+                )}
+              </Button>
+
+              {connectionStatus === 'success' && previewData?.can_add && (
+                <Button
+                  type="button"
+                  onClick={onAdd}
+                  disabled={isAdding}
+                  className="bg-green-600 hover:bg-green-700"
+                >
+                  {isAdding ? (
+                    <>
+                      <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                      Adding...
+                    </>
+                  ) : (
+                    <>
+                      <Plus className="w-4 h-4 mr-2" />
+                      Add Integration
+                    </>
+                  )}
+                </Button>
+              )}
+            </div>
+          </form>
+        </Form>
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/app/integrations/components/RootlyIntegrationForm.tsx
+++ b/frontend/src/app/integrations/components/RootlyIntegrationForm.tsx
@@ -1,0 +1,277 @@
+import { useState } from "react"
+import Image from "next/image"
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
+import { Alert, AlertDescription } from "@/components/ui/alert"
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form"
+import { HelpCircle, ChevronDown, CheckCircle, AlertCircle, Shield, Plus, Loader2, Eye, EyeOff, Copy, Check } from "lucide-react"
+import { UseFormReturn } from "react-hook-form"
+import { RootlyFormData, PreviewData } from "../types"
+
+interface RootlyIntegrationFormProps {
+  form: UseFormReturn<RootlyFormData>
+  onTest: (platform: 'rootly', token: string) => Promise<void>
+  onAdd: () => void
+  connectionStatus: 'idle' | 'success' | 'error' | 'duplicate'
+  previewData: PreviewData | null
+  duplicateInfo: any
+  isTestingConnection: boolean
+  isAdding: boolean
+  isValidToken: (token: string) => boolean
+  onCopyToken: (token: string) => void
+  copied: boolean
+}
+
+export function RootlyIntegrationForm({
+  form,
+  onTest,
+  onAdd,
+  connectionStatus,
+  previewData,
+  duplicateInfo,
+  isTestingConnection,
+  isAdding,
+  isValidToken,
+  onCopyToken,
+  copied
+}: RootlyIntegrationFormProps) {
+  const [showInstructions, setShowInstructions] = useState(false)
+  const [showToken, setShowToken] = useState(false)
+
+  return (
+    <Card className="border-purple-200 max-w-2xl mx-auto">
+      <CardHeader className="p-8">
+        <div className="flex items-center space-x-3">
+          <div className="w-10 h-10 bg-purple-100 rounded-lg flex items-center justify-center">
+            <Image src="/images/rootly-logo-branded.png" alt="Rootly" width={24} height={24} />
+          </div>
+          <div>
+            <CardTitle>Add Rootly Integration</CardTitle>
+            <CardDescription>Connect your Rootly account to analyze incident data</CardDescription>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4 p-8 pt-0">
+        {/* Instructions */}
+        <div>
+          <button
+            type="button"
+            onClick={() => setShowInstructions(!showInstructions)}
+            className="flex items-center space-x-2 text-sm text-purple-600 hover:text-purple-700"
+          >
+            <HelpCircle className="w-4 h-4" />
+            <span>How to get your Rootly API token</span>
+            <ChevronDown className={`w-4 h-4 transition-transform ${showInstructions ? 'rotate-180' : ''}`} />
+          </button>
+          {showInstructions && (
+            <div className="mt-4">
+              <Alert className="border-purple-200 bg-purple-50">
+                <AlertDescription>
+                  <ol className="space-y-2 text-sm">
+                    <li><strong>1.</strong> Log in to your Rootly account</li>
+                    <li><strong>2.</strong> Navigate to <code className="bg-purple-100 px-1 rounded">Settings → API Keys</code></li>
+                    <li><strong>3.</strong> Click <strong>"Create API Key"</strong></li>
+                    <li><strong>4.</strong> Give it a name (e.g., <strong>"Burnout Detector"</strong>)</li>
+                    <li><strong>5.</strong> Select appropriate permissions (<strong>required:</strong> read access to incidents and users)</li>
+                    <li><strong>6.</strong> Copy the generated token (starts with <strong>"rootly_"</strong>)</li>
+                  </ol>
+                </AlertDescription>
+              </Alert>
+            </div>
+          )}
+        </div>
+
+        {/* Form */}
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit((data) => onTest('rootly', data.rootlyToken))} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="rootlyToken"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Rootly API Token</FormLabel>
+                  <FormControl>
+                    <div className="relative">
+                      <Input
+                        {...field}
+                        type={showToken ? "text" : "password"}
+                        placeholder="rootly_********************************"
+                        className="pr-20"
+                      />
+                      <div className="absolute inset-y-0 right-0 flex items-center space-x-1 pr-3">
+                        {field.value && (
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            className="h-7 w-7 p-0"
+                            onClick={() => onCopyToken(field.value)}
+                          >
+                            {copied ? (
+                              <Check className="h-3 w-3 text-green-600" />
+                            ) : (
+                              <Copy className="h-3 w-3 text-slate-400" />
+                            )}
+                          </Button>
+                        )}
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          className="h-7 w-7 p-0"
+                          onClick={() => setShowToken(!showToken)}
+                        >
+                          {showToken ? (
+                            <EyeOff className="h-3 w-3 text-slate-400" />
+                          ) : (
+                            <Eye className="h-3 w-3 text-slate-400" />
+                          )}
+                        </Button>
+                      </div>
+                    </div>
+                  </FormControl>
+                  <FormDescription>
+                    Token should start with "rootly_" followed by 64 hex characters
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* Connection Status */}
+            {connectionStatus === 'success' && previewData && (
+              <>
+                <Alert className="border-purple-200 bg-purple-50">
+                  <CheckCircle className="h-4 w-4 text-purple-600" />
+                  <AlertDescription className="text-purple-800">
+                    <div className="space-y-2">
+                      <p className="font-semibold">✅ Token validated! Permissions verified.</p>
+                      <p className="text-sm text-purple-700">Ready to add this Rootly integration to your dashboard.</p>
+                      <div className="space-y-1 text-sm">
+                        <p><span className="font-medium">Organization:</span> {previewData.organization_name}</p>
+                        <p><span className="font-medium">Users:</span> {previewData.total_users}</p>
+                        {previewData.permissions && (
+                          <div className="mt-2">
+                            <p className="font-medium">Permissions:</p>
+                            <div className="grid grid-cols-2 gap-2 mt-1">
+                              <div className="flex items-center">
+                                {previewData.permissions.users?.access ? (
+                                  <CheckCircle className="w-3 h-3 text-green-600 mr-1" />
+                                ) : (
+                                  <AlertCircle className="w-3 h-3 text-red-600 mr-1" />
+                                )}
+                                <span className="text-xs">Users</span>
+                              </div>
+                              <div className="flex items-center">
+                                {previewData.permissions.incidents?.access ? (
+                                  <CheckCircle className="w-3 h-3 text-green-600 mr-1" />
+                                ) : (
+                                  <AlertCircle className="w-3 h-3 text-red-600 mr-1" />
+                                )}
+                                <span className="text-xs">Incidents</span>
+                              </div>
+                            </div>
+                            {(!previewData.permissions.users?.access || !previewData.permissions.incidents?.access) && (
+                              <div className="mt-2 p-2 bg-red-50 border border-red-200 rounded text-xs">
+                                <p className="font-medium text-red-800">Missing permissions:</p>
+                                {!previewData.permissions.users?.access && (
+                                  <p className="text-red-700">• Users: {previewData.permissions.users?.error}</p>
+                                )}
+                                {!previewData.permissions.incidents?.access && (
+                                  <p className="text-red-700">• Incidents: {previewData.permissions.incidents?.error}</p>
+                                )}
+                              </div>
+                            )}
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  </AlertDescription>
+                </Alert>
+
+                <FormField
+                  control={form.control}
+                  name="nickname"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Integration Name (optional)</FormLabel>
+                      <FormControl>
+                        <Input
+                          {...field}
+                          placeholder={previewData.suggested_name || previewData.organization_name}
+                        />
+                      </FormControl>
+                      <FormDescription>
+                        Give this integration a custom name
+                      </FormDescription>
+                    </FormItem>
+                  )}
+                />
+              </>
+            )}
+
+            {connectionStatus === 'error' && (
+              <Alert variant="destructive">
+                <AlertCircle className="h-4 w-4" />
+                <AlertDescription>
+                  ❌ Invalid API token. Please verify your Rootly token and try again.
+                </AlertDescription>
+              </Alert>
+            )}
+
+            {connectionStatus === 'duplicate' && duplicateInfo && (
+              <Alert className="border-yellow-200 bg-yellow-50">
+                <AlertCircle className="h-4 w-4 text-yellow-600" />
+                <AlertDescription className="text-yellow-800">
+                  This Rootly account is already connected as "{duplicateInfo.existing_integration?.name || 'Unknown'}".
+                </AlertDescription>
+              </Alert>
+            )}
+
+            <div className="flex space-x-3">
+              <Button
+                type="submit"
+                disabled={isTestingConnection || !isValidToken(form.watch('rootlyToken') || '')}
+                className="bg-purple-600 hover:bg-purple-700"
+              >
+                {isTestingConnection ? (
+                  <>
+                    <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                    Testing Connection...
+                  </>
+                ) : (
+                  <>
+                    <Shield className="w-4 h-4 mr-2" />
+                    Test Connection
+                  </>
+                )}
+              </Button>
+
+              {connectionStatus === 'success' && previewData?.can_add && (
+                <Button
+                  type="button"
+                  onClick={onAdd}
+                  disabled={isAdding}
+                  className="bg-green-600 hover:bg-green-700"
+                >
+                  {isAdding ? (
+                    <>
+                      <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                      Adding...
+                    </>
+                  ) : (
+                    <>
+                      <Plus className="w-4 h-4 mr-2" />
+                      Add Integration
+                    </>
+                  )}
+                </Button>
+              )}
+            </div>
+          </form>
+        </Form>
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/app/integrations/components/SlackConnectedCard.tsx
+++ b/frontend/src/app/integrations/components/SlackConnectedCard.tsx
@@ -1,0 +1,225 @@
+import Image from "next/image"
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Key, Calendar, Building, Clock, Users, Trash2, Loader2, CheckCircle, AlertCircle, RotateCcw } from "lucide-react"
+import { SlackIntegration } from "../types"
+
+interface SlackConnectedCardProps {
+  integration: SlackIntegration
+  slackPermissions: any
+  isLoadingPermissions: boolean
+  onDisconnect: () => void
+  onTest: () => void
+  onViewMappings: () => void
+  onLoadPermissions: () => void
+  loadingMappings: boolean
+  selectedMappingPlatform: string | null
+}
+
+export function SlackConnectedCard({
+  integration,
+  slackPermissions,
+  isLoadingPermissions,
+  onDisconnect,
+  onTest,
+  onViewMappings,
+  onLoadPermissions,
+  loadingMappings,
+  selectedMappingPlatform
+}: SlackConnectedCardProps) {
+  return (
+    <Card className="border-green-200 bg-green-50 max-w-2xl mx-auto">
+      <CardHeader className="p-8">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center space-x-3">
+            <div className="w-10 h-10 rounded-lg flex items-center justify-center">
+              <Image
+                src="/images/slack-logo.png"
+                alt="Slack"
+                width={40}
+                height={40}
+                className="h-10 w-10 object-contain"
+              />
+            </div>
+            <div>
+              <CardTitle>Slack Connected</CardTitle>
+              <CardDescription>User ID: {integration.slack_user_id}</CardDescription>
+            </div>
+          </div>
+          <div className="flex items-center space-x-2">
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={onViewMappings}
+              disabled={loadingMappings}
+              className="bg-purple-50 text-purple-700 border-purple-200 hover:bg-purple-100 hover:text-purple-800 hover:border-purple-300"
+              title="View and manage Slack user mappings"
+            >
+              {loadingMappings && selectedMappingPlatform === 'slack' ? (
+                <>
+                  <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                  Loading...
+                </>
+              ) : (
+                <>
+                  <Users className="w-4 h-4 mr-2" />
+                  View Mappings
+                </>
+              )}
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={onTest}
+              className="h-8 w-8 p-0 text-blue-600 hover:text-blue-700 hover:bg-blue-50"
+            >
+              <RotateCcw className="w-4 h-4" />
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={onDisconnect}
+              className="h-8 w-8 p-0 text-red-600 hover:text-red-700 hover:bg-red-50"
+            >
+              <Trash2 className="w-4 h-4" />
+            </Button>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="p-8 pt-0">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
+            <div className="flex items-center space-x-2">
+              <Key className="w-4 h-4 text-gray-400" />
+              <div>
+                <div className="font-medium">Webhook URL</div>
+                <div className="text-gray-600 font-mono text-xs">
+                  {integration.webhook_preview || 'Not configured'}
+                </div>
+              </div>
+            </div>
+            <div className="flex items-center space-x-2">
+              <Key className="w-4 h-4 text-gray-400" />
+              <div>
+                <div className="font-medium">Bot Token</div>
+                <div className="text-gray-600 font-mono text-xs">
+                  {integration.token_preview || 'Not available'}
+                </div>
+              </div>
+            </div>
+            <div className="flex items-center space-x-2">
+              <Building className="w-4 h-4 text-gray-400" />
+              <div>
+                <div className="font-medium">Workspace ID</div>
+                <div className="text-gray-600 font-mono text-xs">{integration.workspace_id}</div>
+              </div>
+            </div>
+            <div className="flex items-center space-x-2">
+              <Calendar className="w-4 h-4 text-gray-400" />
+              <div>
+                <div className="font-medium">Connected</div>
+                <div className="text-gray-600">{new Date(integration.connected_at).toLocaleDateString()}</div>
+              </div>
+            </div>
+            <div className="flex items-center space-x-2">
+              <Clock className="w-4 h-4 text-gray-400" />
+              <div>
+                <div className="font-medium">Last Updated</div>
+                <div className="text-gray-600">{new Date(integration.last_updated).toLocaleDateString()}</div>
+              </div>
+            </div>
+            <div className="flex items-center space-x-2">
+              <Users className="w-4 h-4 text-gray-400" />
+              <div>
+                <div className="font-medium">User ID</div>
+                <div className="text-gray-600 font-mono text-xs">{integration.slack_user_id}</div>
+              </div>
+            </div>
+          </div>
+
+        {/* Permissions Section */}
+        <div className="border-t pt-4 mt-6">
+          <div className="flex items-center justify-between mb-3">
+            <h4 className="font-medium text-sm">Bot Permissions</h4>
+            {isLoadingPermissions ? (
+              <Loader2 className="w-4 h-4 animate-spin text-gray-400" />
+            ) : (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={onLoadPermissions}
+                className="h-8 w-8 p-0 text-blue-600 hover:text-blue-700 hover:bg-blue-50"
+              >
+                <RotateCcw className="w-4 h-4" />
+              </Button>
+            )}
+          </div>
+          {slackPermissions ? (
+            <div className="grid grid-cols-1 gap-2">
+              {Object.entries(slackPermissions)
+                .filter(([permission]) => ['channels_access', 'users_access', 'channels_history'].includes(permission))
+                .map(([permission, hasAccess]) => {
+                const isGranted = hasAccess === true
+                const permissionLabels: { [key: string]: string } = {
+                  'channels_access': 'Channel Access',
+                  'users_access': 'User Access',
+                  'channels_history': 'Channel History'
+                }
+
+                return (
+                  <div key={permission} className="flex items-center justify-between text-xs">
+                    <span className="text-gray-600">{permissionLabels[permission] || permission}</span>
+                    <div className="flex items-center space-x-1">
+                      {isGranted ? (
+                        <>
+                          <CheckCircle className="w-3 h-3 text-green-500" />
+                          <span className="text-green-600 font-medium">Granted</span>
+                        </>
+                      ) : (
+                        <>
+                          <AlertCircle className="w-3 h-3 text-red-500" />
+                          <span className="text-red-600 font-medium">
+                            {permission === 'channels_history' && slackPermissions.errors?.includes('not_in_channel')
+                              ? 'Bot not in channels'
+                              : 'Missing'}
+                          </span>
+                        </>
+                      )}
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          ) : (
+            <div className="text-xs text-gray-500">
+              Click "Test" or the refresh icon to check permissions
+            </div>
+          )}
+        </div>
+
+        {/* Bot Channels Section */}
+        <div className="mt-6">
+          <div className="flex items-center justify-between mb-3">
+            <h4 className="font-medium text-sm">Bot Channels</h4>
+          </div>
+          {integration?.channel_names && integration.channel_names.length > 0 ? (
+            <div className="space-y-1">
+              {integration.channel_names.map((channelName: string) => (
+                <div key={channelName} className="flex items-center space-x-2 text-xs">
+                  <span className="text-gray-400">#</span>
+                  <span className="text-gray-700">{channelName}</span>
+                  <CheckCircle className="w-3 h-3 text-green-500" />
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="text-xs text-gray-500">
+              {slackPermissions?.errors?.includes('not_in_channel')
+                ? 'Bot is not in any channels. Add it to channels in Slack.'
+                : 'No channels found'}
+            </div>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/app/integrations/components/SlackIntegrationCard.tsx
+++ b/frontend/src/app/integrations/components/SlackIntegrationCard.tsx
@@ -1,0 +1,208 @@
+import { useState } from "react"
+import Image from "next/image"
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
+import { Alert, AlertDescription } from "@/components/ui/alert"
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+import { HelpCircle, ChevronDown, ExternalLink, Eye, EyeOff, Loader2 } from "lucide-react"
+
+interface SlackIntegrationCardProps {
+  onConnect: (webhookUrl: string, botToken: string) => Promise<void>
+  isConnecting: boolean
+}
+
+export function SlackIntegrationCard({ onConnect, isConnecting }: SlackIntegrationCardProps) {
+  const [showInstructions, setShowInstructions] = useState(false)
+  const [webhookUrl, setWebhookUrl] = useState("")
+  const [botToken, setBotToken] = useState("")
+  const [showWebhook, setShowWebhook] = useState(false)
+  const [showToken, setShowToken] = useState(false)
+
+  return (
+    <Card className="border-purple-200 max-w-2xl mx-auto">
+      <CardHeader className="p-8">
+        <div className="flex items-center space-x-3">
+          <div className="w-10 h-10 rounded-lg flex items-center justify-center">
+            <Image
+              src="/images/slack-logo.png"
+              alt="Slack"
+              width={40}
+              height={40}
+              className="h-10 w-10 object-contain"
+            />
+          </div>
+          <div>
+            <CardTitle>Add Slack Integration</CardTitle>
+            <CardDescription>Connect your Slack workspace to analyze communication patterns</CardDescription>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4 p-8 pt-0">
+        {/* Instructions */}
+        <div>
+          <button
+            type="button"
+            onClick={() => setShowInstructions(!showInstructions)}
+            className="flex items-center space-x-2 text-sm text-purple-600 hover:text-purple-700"
+          >
+            <HelpCircle className="w-4 h-4" />
+            <span>How to get your Slack credentials</span>
+            <ChevronDown className={`w-4 h-4 transition-transform ${showInstructions ? 'rotate-180' : ''}`} />
+          </button>
+          {showInstructions && (
+            <div className="mt-4">
+              <Alert className="border-purple-200 bg-purple-50">
+                <AlertDescription>
+                  <div className="space-y-4">
+                    <div>
+                      <h4 className="font-medium text-purple-900 mb-2"><strong>Step 1:</strong> Create a Slack App</h4>
+                      <p className="text-sm text-purple-800 mb-2">
+                        Go to the <strong>Slack API website</strong> and create a new app:
+                      </p>
+                      <a
+                        href="https://api.slack.com/apps"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center text-sm text-blue-600 hover:underline"
+                      >
+                        Create Slack App <ExternalLink className="w-3 h-3 ml-1" />
+                      </a>
+                      <p className="text-sm text-purple-800 mt-2">Click "Create New App" → "From scratch" → Enter app name and select your workspace</p>
+                    </div>
+
+                    <div>
+                      <h4 className="font-medium text-purple-900 mb-2">Step 2: Configure Incoming Webhooks</h4>
+                      <p className="text-sm text-purple-800 mb-2">In your app settings:</p>
+                      <ul className="text-sm text-purple-800 space-y-1 ml-4">
+                        <li>• Go to "Incoming Webhooks" in the sidebar</li>
+                        <li>• Toggle "Activate Incoming Webhooks" to <strong>On</strong></li>
+                        <li>• Click "Add New Webhook to Workspace"</li>
+                        <li>• Select a channel and click "Allow"</li>
+                        <li>• Copy the webhook URL (starts with <code className="bg-purple-200 px-1 rounded">https://hooks.slack.com/</code>)</li>
+                      </ul>
+                    </div>
+
+                    <div>
+                      <h4 className="font-medium text-purple-900 mb-2">Step 3: Add Bot Token Scopes</h4>
+                      <p className="text-sm text-purple-800 mb-2">In "OAuth & Permissions" → "Scopes" → "Bot Token Scopes", add these <strong>3 required scopes</strong>:</p>
+                      <ul className="text-sm text-purple-800 space-y-1 ml-4">
+                        <li>• <code className="bg-purple-200 px-1 rounded">channels:read</code> - View basic channel information</li>
+                        <li>• <code className="bg-purple-200 px-1 rounded">channels:history</code> - Read public channel messages</li>
+                        <li>• <code className="bg-purple-200 px-1 rounded">users:read</code> - View user information</li>
+                      </ul>
+                      <div className="mt-2 p-2 bg-amber-100 border border-amber-300 rounded text-xs text-amber-800">
+                        <strong>Important:</strong> After adding scopes, you MUST reinstall the app to your workspace for changes to take effect.
+                      </div>
+                    </div>
+
+                    <div>
+                      <h4 className="font-medium text-purple-900 mb-2">Step 4: Install App and Get Bot Token</h4>
+                      <ul className="text-sm text-purple-800 space-y-1 ml-4">
+                        <li>• Click "Install to Workspace" at the top of OAuth & Permissions</li>
+                        <li>• Review permissions and click "Allow"</li>
+                        <li>• Copy the "Bot User OAuth Token" (starts with <code className="bg-purple-200 px-1 rounded">xoxb-</code>)</li>
+                      </ul>
+                    </div>
+
+                    <div>
+                      <h4 className="font-medium text-purple-900 mb-2">Step 5: Add Bot to Channels</h4>
+                      <p className="text-sm text-purple-800 mb-2">After setup, add the bot to relevant channels:</p>
+                      <ul className="text-sm text-purple-800 space-y-1 ml-4">
+                        <li>• Go to each channel you want analyzed in Slack</li>
+                        <li>• Type <code className="bg-purple-200 px-1 rounded">@Burnout Detector</code> and invite the bot</li>
+                        <li>• The bot must be in channels to read message history</li>
+                      </ul>
+                      <div className="mt-2 p-2 bg-red-100 border border-red-300 rounded text-xs text-red-800">
+                        <strong>Required:</strong> Bot permissions will show "Bot not in channels" until you add it to at least one channel.
+                      </div>
+                    </div>
+
+                    <div className="bg-purple-100 border border-purple-300 rounded p-3">
+                      <p className="text-sm text-purple-800">
+                        <strong>Note:</strong> You'll need both the webhook URL and bot token. The webhook is for sending notifications,
+                        and the bot token is for reading messages and user data.
+                      </p>
+                    </div>
+                  </div>
+                </AlertDescription>
+              </Alert>
+            </div>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          <label htmlFor="slack-webhook" className="text-sm font-medium">Slack Webhook URL</label>
+          <div className="relative">
+            <Input
+              id="slack-webhook"
+              type={showWebhook ? "text" : "password"}
+              placeholder="https://hooks.slack.com/services/..."
+              className="pr-10"
+              value={webhookUrl}
+              onChange={(e) => setWebhookUrl(e.target.value)}
+            />
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
+              onClick={() => setShowWebhook(!showWebhook)}
+            >
+              {showWebhook ? (
+                <EyeOff className="h-4 w-4 text-gray-400" />
+              ) : (
+                <Eye className="h-4 w-4 text-gray-400" />
+              )}
+            </Button>
+          </div>
+          <p className="text-sm text-gray-500">
+            URL should start with "https://hooks.slack.com/services/"
+          </p>
+        </div>
+        <div className="space-y-2">
+          <label htmlFor="slack-token" className="text-sm font-medium">Slack Bot Token</label>
+          <div className="relative">
+            <Input
+              id="slack-token"
+              type={showToken ? "text" : "password"}
+              placeholder="xoxb-xxxxxxxxxxxx-xxxxxxxxxxxx"
+              className="pr-10"
+              value={botToken}
+              onChange={(e) => setBotToken(e.target.value)}
+            />
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
+              onClick={() => setShowToken(!showToken)}
+            >
+              {showToken ? (
+                <EyeOff className="h-4 w-4 text-gray-400" />
+              ) : (
+                <Eye className="h-4 w-4 text-gray-400" />
+              )}
+            </Button>
+          </div>
+          <p className="text-sm text-gray-500">
+            Token should start with "xoxb-" followed by your bot token
+          </p>
+        </div>
+        <Button
+          className="bg-purple-600 hover:bg-purple-700 text-white"
+          onClick={() => webhookUrl && botToken && onConnect(webhookUrl, botToken)}
+          disabled={!webhookUrl || !botToken || isConnecting}
+        >
+          {isConnecting ? (
+            <>
+              <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+              Connecting...
+            </>
+          ) : (
+            'Connect Slack'
+          )}
+        </Button>
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/app/integrations/dialogs/DeleteIntegrationDialog.tsx
+++ b/frontend/src/app/integrations/dialogs/DeleteIntegrationDialog.tsx
@@ -1,0 +1,58 @@
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Loader2 } from "lucide-react"
+import { Integration } from "../types"
+
+interface DeleteIntegrationDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  integration: Integration | null
+  isDeleting: boolean
+  onConfirmDelete: () => void
+  onCancel: () => void
+}
+
+export function DeleteIntegrationDialog({
+  open,
+  onOpenChange,
+  integration,
+  isDeleting,
+  onConfirmDelete,
+  onCancel
+}: DeleteIntegrationDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Delete Integration</DialogTitle>
+          <DialogDescription>
+            Are you sure you want to delete "{integration?.name}"?
+            This action cannot be undone.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={onCancel}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={onConfirmDelete}
+            disabled={isDeleting}
+          >
+            {isDeleting ? (
+              <>
+                <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                Deleting...
+              </>
+            ) : (
+              "Delete Integration"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/app/integrations/dialogs/GitHubDisconnectDialog.tsx
+++ b/frontend/src/app/integrations/dialogs/GitHubDisconnectDialog.tsx
@@ -1,0 +1,54 @@
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Loader2 } from "lucide-react"
+
+interface GitHubDisconnectDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  isDisconnecting: boolean
+  onConfirmDisconnect: () => void
+}
+
+export function GitHubDisconnectDialog({
+  open,
+  onOpenChange,
+  isDisconnecting,
+  onConfirmDisconnect
+}: GitHubDisconnectDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Disconnect GitHub Integration</DialogTitle>
+          <DialogDescription>
+            Are you sure you want to disconnect your GitHub integration?
+            This will remove access to your GitHub data and you'll need to reconnect to use GitHub features again.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isDisconnecting}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={onConfirmDisconnect}
+            disabled={isDisconnecting}
+          >
+            {isDisconnecting ? (
+              <>
+                <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                Disconnecting...
+              </>
+            ) : (
+              "Disconnect GitHub"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/app/integrations/dialogs/NewMappingDialog.tsx
+++ b/frontend/src/app/integrations/dialogs/NewMappingDialog.tsx
@@ -1,0 +1,125 @@
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Plus } from "lucide-react"
+
+interface NewMappingForm {
+  source_platform: string
+  source_identifier: string
+  target_platform: string
+  target_identifier: string
+}
+
+interface NewMappingDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  form: NewMappingForm
+  onFormChange: (form: NewMappingForm) => void
+  selectedPlatform: 'github' | 'slack' | null
+  onCreateMapping: () => void
+}
+
+export function NewMappingDialog({
+  open,
+  onOpenChange,
+  form,
+  onFormChange,
+  selectedPlatform,
+  onCreateMapping
+}: NewMappingDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle className="flex items-center space-x-2">
+            <Plus className="w-5 h-5" />
+            <span>Create New Manual Mapping</span>
+          </DialogTitle>
+          <DialogDescription>
+            Create a manual mapping between a source platform user and {selectedPlatform === 'github' ? 'GitHub' : 'Slack'} account.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <label className="text-sm font-medium">Source Platform</label>
+              <Select
+                value={form.source_platform}
+                onValueChange={(value) => onFormChange({...form, source_platform: value})}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Select source platform" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="rootly">Rootly</SelectItem>
+                  <SelectItem value="pagerduty">PagerDuty</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium">Target Platform</label>
+              <Select
+                value={form.target_platform}
+                onValueChange={(value) => onFormChange({...form, target_platform: value})}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Select target platform" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="github">GitHub</SelectItem>
+                  <SelectItem value="slack">Slack</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium">Source Identifier</label>
+            <Input
+              placeholder="e.g., john.doe@company.com or John Doe"
+              value={form.source_identifier}
+              onChange={(e) => onFormChange({...form, source_identifier: e.target.value})}
+            />
+            <p className="text-xs text-gray-500">
+              The email or name as it appears in {form.source_platform} incidents
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium">Target Identifier</label>
+            <Input
+              placeholder={
+                form.target_platform === 'github'
+                  ? "e.g., johndoe or john-doe-123"
+                  : "e.g., U1234567890 or @johndoe"
+              }
+              value={form.target_identifier}
+              onChange={(e) => onFormChange({...form, target_identifier: e.target.value})}
+            />
+            <p className="text-xs text-gray-500">
+              The {form.target_platform === 'github' ? 'GitHub username' : 'Slack user ID or @username'}
+            </p>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={onCreateMapping}
+            disabled={!form.source_identifier || !form.target_identifier}
+          >
+            Create Mapping
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/app/integrations/dialogs/OrganizationManagementDialog.tsx
+++ b/frontend/src/app/integrations/dialogs/OrganizationManagementDialog.tsx
@@ -1,0 +1,277 @@
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Users, Mail, Loader2 } from "lucide-react"
+import { UserInfo } from "../types"
+
+interface OrganizationMember {
+  id: number
+  name: string
+  email: string
+  role: string
+  is_current_user: boolean
+}
+
+interface PendingInvitation {
+  id: number
+  email: string
+  role: string
+  invited_by: { name: string } | null
+  created_at: string
+  expires_at: string
+  is_expired: boolean
+}
+
+interface OrganizationManagementDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  inviteEmail: string
+  onInviteEmailChange: (email: string) => void
+  inviteRole: string
+  onInviteRoleChange: (role: string) => void
+  isInviting: boolean
+  onInvite: () => void
+  loadingOrgData: boolean
+  orgMembers: OrganizationMember[]
+  pendingInvitations: PendingInvitation[]
+  userInfo: UserInfo | null
+  onRoleChange: (userId: number, newRole: string) => void
+  onClose: () => void
+}
+
+export function OrganizationManagementDialog({
+  open,
+  onOpenChange,
+  inviteEmail,
+  onInviteEmailChange,
+  inviteRole,
+  onInviteRoleChange,
+  isInviting,
+  onInvite,
+  loadingOrgData,
+  orgMembers,
+  pendingInvitations,
+  userInfo,
+  onRoleChange,
+  onClose
+}: OrganizationManagementDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-4xl max-h-[80vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle className="flex items-center space-x-2">
+            <Users className="w-5 h-5" />
+            <span>Organization Management</span>
+          </DialogTitle>
+          <DialogDescription>
+            Invite new members and manage your organization
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* Role descriptions - at the top of modal */}
+        <div className="mt-4 px-4 py-3 bg-gradient-to-r from-purple-50 to-blue-50 rounded-lg">
+          <div className="space-y-1.5 text-xs">
+            <div className="flex items-baseline space-x-2">
+              <span className="font-semibold text-gray-900 min-w-[80px]">Org Admin</span>
+              <span className="text-gray-700">Everything a Manager can do, plus manage integrations, invite members, and configure settings</span>
+            </div>
+            <div className="flex items-baseline space-x-2">
+              <span className="font-semibold text-gray-900 min-w-[80px]">Manager</span>
+              <span className="text-gray-700">Full access to view team burnout data, run analyses, and send surveys</span>
+            </div>
+          </div>
+        </div>
+
+        <div className="space-y-6">
+          {/* Invite New Member Section */}
+          <div className="p-6 border rounded-lg bg-gradient-to-br from-purple-50 to-white">
+            <div className="flex items-start space-x-4">
+              <div className="flex-shrink-0 w-10 h-10 bg-purple-100 rounded-lg flex items-center justify-center">
+                <Mail className="w-5 h-5 text-purple-600" />
+              </div>
+              <div className="flex-1 space-y-4">
+                <div>
+                  <h3 className="text-lg font-semibold text-gray-900">Invite Team Member</h3>
+                  <p className="text-sm text-gray-500 mt-1">Send an invitation to join your organization</p>
+                </div>
+
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <div>
+                    <label htmlFor="invite-email" className="block text-sm font-medium text-gray-700 mb-1.5">
+                      Email Address
+                    </label>
+                    <Input
+                      id="invite-email"
+                      type="email"
+                      placeholder="colleague@company.com"
+                      value={inviteEmail}
+                      onChange={(e) => onInviteEmailChange(e.target.value)}
+                      className="w-full"
+                    />
+                  </div>
+                  <div>
+                    <label htmlFor="invite-role" className="block text-sm font-medium text-gray-700 mb-1.5">
+                      Role
+                    </label>
+                    <select
+                      id="invite-role"
+                      value={inviteRole}
+                      onChange={(e) => onInviteRoleChange(e.target.value)}
+                      className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple-500 bg-white"
+                    >
+                      <option value="manager">Manager</option>
+                      <option value="org_admin">Org Admin</option>
+                    </select>
+                  </div>
+                </div>
+
+                <Button
+                  onClick={onInvite}
+                  disabled={isInviting || !inviteEmail.trim()}
+                  className="w-full md:w-auto bg-purple-600 hover:bg-purple-700"
+                >
+                  {isInviting ? (
+                    <>
+                      <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                      Sending Invitation...
+                    </>
+                  ) : (
+                    <>
+                      <Mail className="w-4 h-4 mr-2" />
+                      Send Invitation
+                    </>
+                  )}
+                </Button>
+              </div>
+            </div>
+          </div>
+
+          {/* Current Members & Pending Invitations */}
+          {loadingOrgData ? (
+            <div className="text-center py-8">
+              <Loader2 className="w-8 h-8 mx-auto mb-4 animate-spin text-gray-400" />
+              <p className="text-gray-500">Loading organization data...</p>
+            </div>
+          ) : (
+            <div className="space-y-6">
+              {/* Current Members */}
+              {orgMembers.length > 0 && (
+                <div>
+                  <h3 className="text-lg font-medium mb-3 flex items-center space-x-2">
+                    <Users className="w-5 h-5" />
+                    <span>Organization Members ({orgMembers.length})</span>
+                  </h3>
+                  <div className="border rounded-lg overflow-hidden">
+                    <div className="bg-gray-50 px-4 py-2 border-b">
+                      <div className="grid grid-cols-3 gap-4 text-sm font-medium text-gray-700">
+                        <div>Name</div>
+                        <div>Email</div>
+                        <div>Role</div>
+                      </div>
+                    </div>
+                    <div className="max-h-60 overflow-y-auto">
+                      {orgMembers.map((member) => (
+                        <div key={member.id} className="px-4 py-3 border-b last:border-b-0 bg-white hover:bg-gray-50">
+                          <div className="grid grid-cols-3 gap-4 text-sm items-center">
+                            <div className="font-medium text-gray-900">
+                              {member.name}
+                              {member.is_current_user && (
+                                <span className="ml-2 text-xs bg-blue-100 text-blue-800 px-2 py-1 rounded">You</span>
+                              )}
+                            </div>
+                            <div className="text-gray-600">{member.email}</div>
+                            <div>
+                              {member.is_current_user ? (
+                                <span className="inline-block px-2 py-1 text-xs rounded-full bg-green-100 text-green-800 capitalize">
+                                  {member.role?.replace('_', ' ') || 'member'}
+                                </span>
+                              ) : (
+                                <select
+                                  value={member.role || 'manager'}
+                                  onChange={(e) => onRoleChange(member.id, e.target.value)}
+                                  className="text-xs px-2 py-1 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple-500 bg-white"
+                                  disabled={userInfo?.role !== 'org_admin'}
+                                >
+                                  <option value="manager">Manager</option>
+                                  <option value="org_admin">Org Admin</option>
+                                </select>
+                              )}
+                            </div>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {/* Pending Invitations */}
+              {pendingInvitations.length > 0 && (
+                <div>
+                  <h3 className="text-lg font-medium mb-3 flex items-center space-x-2">
+                    <Mail className="w-5 h-5" />
+                    <span>Pending Invitations ({pendingInvitations.length})</span>
+                  </h3>
+                  <div className="border rounded-lg overflow-hidden">
+                    <div className="bg-gray-50 px-4 py-2 border-b">
+                      <div className="grid grid-cols-5 gap-4 text-sm font-medium text-gray-700">
+                        <div>Email</div>
+                        <div>Role</div>
+                        <div>Invited By</div>
+                        <div>Sent</div>
+                        <div>Expires</div>
+                      </div>
+                    </div>
+                    <div className="max-h-60 overflow-y-auto">
+                      {pendingInvitations.map((invitation) => (
+                        <div key={invitation.id} className="px-4 py-3 border-b last:border-b-0 bg-yellow-50">
+                          <div className="grid grid-cols-5 gap-4 text-sm">
+                            <div className="font-medium text-gray-900">{invitation.email}</div>
+                            <div>
+                              <span className="inline-block px-2 py-1 text-xs rounded-full bg-yellow-100 text-yellow-800 capitalize">
+                                {invitation.role?.replace('_', ' ') || 'member'}
+                              </span>
+                            </div>
+                            <div className="text-gray-600">{invitation.invited_by?.name || 'Unknown'}</div>
+                            <div className="text-gray-500 text-xs">
+                              {new Date(invitation.created_at).toLocaleDateString()}
+                            </div>
+                            <div className="text-gray-500 text-xs">
+                              {invitation.is_expired ? (
+                                <span className="text-red-600">Expired</span>
+                              ) : (
+                                new Date(invitation.expires_at).toLocaleDateString()
+                              )}
+                            </div>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {/* Empty State */}
+              {!loadingOrgData && orgMembers.length === 0 && pendingInvitations.length === 0 && (
+                <div className="text-center py-8 text-gray-500">
+                  <Users className="w-12 h-12 mx-auto mb-4 opacity-50" />
+                  <p>No organization members or pending invitations found</p>
+                  <p className="text-sm mt-1">Start by inviting team members above</p>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={onClose}
+          >
+            Close
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/app/integrations/dialogs/SlackDisconnectDialog.tsx
+++ b/frontend/src/app/integrations/dialogs/SlackDisconnectDialog.tsx
@@ -1,0 +1,54 @@
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Loader2 } from "lucide-react"
+
+interface SlackDisconnectDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  isDisconnecting: boolean
+  onConfirmDisconnect: () => void
+}
+
+export function SlackDisconnectDialog({
+  open,
+  onOpenChange,
+  isDisconnecting,
+  onConfirmDisconnect
+}: SlackDisconnectDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Disconnect Slack Integration</DialogTitle>
+          <DialogDescription>
+            Are you sure you want to disconnect your Slack integration?
+            This will remove access to your Slack workspace data and you'll need to reconnect to use Slack features again.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isDisconnecting}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={onConfirmDisconnect}
+            disabled={isDisconnecting}
+          >
+            {isDisconnecting ? (
+              <>
+                <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                Disconnecting...
+              </>
+            ) : (
+              "Disconnect Slack"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/app/integrations/handlers/ai-handlers.ts
+++ b/frontend/src/app/integrations/handlers/ai-handlers.ts
@@ -1,0 +1,162 @@
+import { toast } from "sonner"
+import { API_BASE } from "../types"
+
+/**
+ * Load LLM configuration
+ */
+export async function loadLlmConfig(
+  setLoadingLlmConfig: (loading: boolean) => void,
+  setLlmConfig: (config: any) => void,
+  setLlmProvider: (provider: string) => void,
+  setLlmModel: (model: string) => void
+): Promise<void> {
+  setLoadingLlmConfig(true)
+  try {
+    const authToken = localStorage.getItem('auth_token')
+    if (!authToken) {
+      return
+    }
+
+    const response = await fetch(`${API_BASE}/llm/token`, {
+      headers: {
+        'Authorization': `Bearer ${authToken}`
+      }
+    })
+
+    if (response.ok) {
+      const config = await response.json()
+      setLlmConfig(config)
+      if (config.provider) {
+        setLlmProvider(config.provider)
+        setLlmModel(config.provider === 'openai' ? 'gpt-4o-mini' : 'claude-3-haiku')
+      }
+    }
+  } catch (error) {
+    console.error('Failed to load LLM config:', error)
+  } finally {
+    setLoadingLlmConfig(false)
+  }
+}
+
+/**
+ * Connect AI/LLM provider with API token
+ */
+export async function handleConnectAI(
+  llmToken: string,
+  llmProvider: string,
+  llmModel: string,
+  setIsConnectingAI: (loading: boolean) => void,
+  setTokenError: (error: string | null) => void,
+  setLlmConfig: (config: any) => void,
+  setLlmToken: (token: string) => void
+): Promise<void> {
+  if (!llmToken.trim()) {
+    setTokenError("Please enter your LLM API token")
+    toast.error("Please enter your LLM API token")
+    return
+  }
+
+  setIsConnectingAI(true)
+  setTokenError(null) // Clear any previous errors
+  try {
+    const authToken = localStorage.getItem('auth_token')
+    if (!authToken) {
+      throw new Error('No authentication token found')
+    }
+
+    const response = await fetch(`${API_BASE}/llm/token`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${authToken}`
+      },
+      body: JSON.stringify({
+        token: llmToken,
+        provider: llmProvider
+      })
+    })
+
+    if (response.ok) {
+      const result = await response.json()
+      setLlmConfig({
+        has_token: true,
+        provider: result.provider,
+        token_suffix: result.token_suffix
+      })
+      setLlmToken('')
+      setTokenError(null) // Clear any errors on success
+      toast.success(`Successfully connected ${result.provider} ${llmModel}`)
+    } else {
+      const error = await response.json()
+      const errorDetail = error.detail || 'Failed to connect AI'
+
+      // Provide specific feedback based on error type
+      let title = "Connection Failed"
+      let description = errorDetail
+
+      if (errorDetail.includes('format')) {
+        title = "Invalid Token Format"
+        description = `${llmProvider === 'openai' ? 'OpenAI' : 'Anthropic'} tokens must start with "${llmProvider === 'openai' ? 'sk-' : 'sk-ant-api'}"`
+      } else if (errorDetail.includes('verification failed') || errorDetail.includes('check your')) {
+        title = "Invalid API Token"
+        description = `The ${llmProvider === 'openai' ? 'OpenAI' : 'Anthropic'} token appears to be invalid or expired. Please verify your token and try again.`
+      } else if (errorDetail.includes('connect')) {
+        title = "Connection Error"
+        description = `Unable to connect to ${llmProvider === 'openai' ? 'OpenAI' : 'Anthropic'} API. Please check your internet connection and try again.`
+      }
+
+      throw new Error(description)
+    }
+  } catch (error) {
+    console.error('Failed to connect AI:', error)
+    const errorMessage = error instanceof Error ? error.message : "Failed to connect to AI service"
+
+    // Determine toast title based on error content
+    let toastTitle = "Connection Failed"
+    if (errorMessage.includes('Invalid Token Format') || errorMessage.includes('must start with')) {
+      toastTitle = "Invalid Token Format"
+    } else if (errorMessage.includes('invalid or expired') || errorMessage.includes('verify your token')) {
+      toastTitle = "Invalid API Token"
+    } else if (errorMessage.includes('Connection Error') || errorMessage.includes('internet connection')) {
+      toastTitle = "Connection Error"
+    }
+
+    // Set the error on the input field as well
+    setTokenError(errorMessage)
+
+    toast.error(errorMessage)
+  } finally {
+    setIsConnectingAI(false)
+  }
+}
+
+/**
+ * Disconnect AI/LLM provider
+ */
+export async function handleDisconnectAI(
+  setLlmConfig: (config: any) => void
+): Promise<void> {
+  try {
+    const authToken = localStorage.getItem('auth_token')
+    if (!authToken) {
+      throw new Error('No authentication token found')
+    }
+
+    const response = await fetch(`${API_BASE}/llm/token`, {
+      method: 'DELETE',
+      headers: {
+        'Authorization': `Bearer ${authToken}`
+      }
+    })
+
+    if (response.ok) {
+      setLlmConfig({has_token: false})
+      toast.success("LLM token removed successfully")
+    } else {
+      throw new Error('Failed to disconnect AI')
+    }
+  } catch (error) {
+    console.error('Failed to disconnect AI:', error)
+    toast.error("Failed to disconnect AI service")
+  }
+}

--- a/frontend/src/app/integrations/handlers/github-handlers.ts
+++ b/frontend/src/app/integrations/handlers/github-handlers.ts
@@ -1,0 +1,165 @@
+import { toast } from "sonner"
+import { type GitHubIntegration, API_BASE } from "../types"
+
+/**
+ * Load GitHub integration from API with caching
+ */
+export async function loadGitHubIntegration(
+  forceRefresh: boolean,
+  setGithubIntegration: (integration: GitHubIntegration | null) => void,
+  setLoadingGitHub: (loading: boolean) => void
+): Promise<void> {
+  if (!forceRefresh) {
+    const cached = localStorage.getItem('github_integration')
+    if (cached) {
+      try {
+        const githubData = JSON.parse(cached)
+        setGithubIntegration(githubData.connected ? githubData.integration : null)
+        setLoadingGitHub(false)
+        return
+      } catch (e) {
+        // Cache parse failed, continue to API call
+      }
+    }
+  }
+
+  try {
+    const authToken = localStorage.getItem('auth_token')
+    if (!authToken) return
+
+    const response = await fetch(`${API_BASE}/integrations/github/status`, {
+      headers: { 'Authorization': `Bearer ${authToken}` }
+    })
+
+    const githubData = response.ok ? await response.json() : { connected: false, integration: null }
+    setGithubIntegration(githubData.connected ? githubData.integration : null)
+    localStorage.setItem('github_integration', JSON.stringify(githubData))
+  } catch (error) {
+    console.error('Error loading GitHub integration:', error)
+  } finally {
+    setLoadingGitHub(false)
+  }
+}
+
+/**
+ * Connect GitHub integration with personal access token
+ */
+export async function handleGitHubConnect(
+  token: string,
+  setIsConnectingGithub: (loading: boolean) => void,
+  setGithubToken: (token: string) => void,
+  setActiveEnhancementTab: (tab: "github" | "slack" | null) => void,
+  loadGitHubIntegration: (forceRefresh: boolean) => void
+): Promise<void> {
+  setIsConnectingGithub(true)
+  try {
+    const authToken = localStorage.getItem('auth_token')
+    if (!authToken) {
+      throw new Error('No authentication token found')
+    }
+
+    const response = await fetch(`${API_BASE}/integrations/github/token`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${authToken}`
+      },
+      body: JSON.stringify({ token })
+    })
+
+    if (!response.ok) {
+      const errorData = await response.json()
+      throw new Error(errorData.detail || 'Failed to connect GitHub')
+    }
+
+    toast.success("Your GitHub account has been connected successfully.")
+
+    setGithubToken('')
+    setActiveEnhancementTab(null)
+    loadGitHubIntegration(true) // Force refresh to update cache
+  } catch (error) {
+    console.error('Error connecting GitHub:', error)
+    toast.error(error instanceof Error ? error.message : "An unexpected error occurred.")
+  } finally {
+    setIsConnectingGithub(false)
+  }
+}
+
+/**
+ * Disconnect GitHub integration
+ */
+export async function handleGitHubDisconnect(
+  setIsDisconnectingGithub: (loading: boolean) => void,
+  setGithubDisconnectDialogOpen: (open: boolean) => void,
+  loadGitHubIntegration: (forceRefresh: boolean) => void
+): Promise<void> {
+  setIsDisconnectingGithub(true)
+  try {
+    const authToken = localStorage.getItem('auth_token')
+    if (!authToken) return
+
+    const response = await fetch(`${API_BASE}/integrations/github/disconnect`, {
+      method: 'DELETE',
+      headers: {
+        'Authorization': `Bearer ${authToken}`
+      }
+    })
+
+    if (response.ok) {
+      toast.success("Your GitHub integration has been removed.")
+      setGithubDisconnectDialogOpen(false)
+      loadGitHubIntegration(true) // Force refresh after changes
+    }
+  } catch (error) {
+    console.error('Error disconnecting GitHub:', error)
+    toast.error(error instanceof Error ? error.message : "An unexpected error occurred.")
+  } finally {
+    setIsDisconnectingGithub(false)
+  }
+}
+
+/**
+ * Test GitHub connection and permissions
+ */
+export async function handleGitHubTest(): Promise<void> {
+  try {
+    const authToken = localStorage.getItem('auth_token')
+    if (!authToken) {
+      toast.error("Please log in to test your GitHub integration.")
+      return
+    }
+
+    toast.info("Testing GitHub connection...")
+
+    const response = await fetch(`${API_BASE}/integrations/github/test`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${authToken}`
+      }
+    })
+
+    if (response.ok) {
+      const data = await response.json()
+      // Show permissions info if available
+      if (data.permissions) {
+        const missingPerms = []
+        if (!data.permissions.repo_access) missingPerms.push('repository access')
+        if (!data.permissions.org_access) missingPerms.push('organization access')
+
+        if (missingPerms.length > 0) {
+          toast.warning(`✅ Connected as ${data.user_info?.username || 'GitHub user'}, but missing: ${missingPerms.join(', ')}`)
+        } else {
+          toast.success(`✅ GitHub test successful! Connected as ${data.user_info?.username || 'GitHub user'} with full access.`)
+        }
+      } else {
+        toast.success(`✅ GitHub test successful! Connected as ${data.user_info?.username || 'GitHub user'}. Integration is working properly.`)
+      }
+    } else {
+      const errorData = await response.json().catch(() => ({}))
+      throw new Error(errorData.detail || 'Connection test failed')
+    }
+  } catch (error) {
+    console.error('Error testing GitHub connection:', error)
+    toast.error(`❌ GitHub test failed: ${error instanceof Error ? error.message : "Unable to test GitHub connection."}`)
+  }
+}

--- a/frontend/src/app/integrations/handlers/integration-handlers.ts
+++ b/frontend/src/app/integrations/handlers/integration-handlers.ts
@@ -1,0 +1,439 @@
+import { toast } from "sonner"
+import { type Integration, API_BASE } from "../types"
+
+/**
+ * Test connection to Rootly or PagerDuty with API token
+ */
+export async function testConnection(
+  platform: "rootly" | "pagerduty",
+  token: string,
+  setIsTestingConnection: (loading: boolean) => void,
+  setConnectionStatus: React.Dispatch<React.SetStateAction<"error" | "success" | "idle" | "duplicate">>,
+  setPreviewData: (data: any) => void,
+  setDuplicateInfo: (info: any) => void
+): Promise<void> {
+  setIsTestingConnection(true)
+  setConnectionStatus('idle')
+  setPreviewData(null)
+
+  try {
+    const authToken = localStorage.getItem('auth_token')
+    if (!authToken) {
+      throw new Error('No authentication token found')
+    }
+
+    const endpoint = platform === 'rootly'
+      ? `${API_BASE}/rootly/token/test`
+      : `${API_BASE}/pagerduty/token/test`
+
+
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${authToken}`
+      },
+      body: JSON.stringify({
+        token: token
+      })
+    })
+
+    const data = await response.json()
+
+
+    if (response.ok && (data.valid || data.status === 'success')) {
+      setConnectionStatus('success')
+      if (platform === 'rootly') {
+        setPreviewData({
+          organization_name: data.preview?.organization_name || data.account_info?.organization_name,
+          total_users: data.preview?.total_users || data.account_info?.total_users,
+          suggested_name: data.preview?.suggested_name || data.account_info?.suggested_name,
+          can_add: data.preview?.can_add || data.account_info?.can_add,
+          permissions: data.account_info?.permissions
+        })
+      } else {
+        setPreviewData(data.account_info)
+      }
+    } else if (response.status === 409) {
+      setConnectionStatus('duplicate')
+      setDuplicateInfo(data.detail)
+    } else {
+      setConnectionStatus('error')
+    }
+  } catch (error) {
+    console.error('Connection test error:', error)
+    setConnectionStatus('error')
+  } finally {
+    setIsTestingConnection(false)
+  }
+}
+
+/**
+ * Load Rootly integrations with caching
+ */
+export async function loadRootlyIntegrations(
+  forceRefresh: boolean,
+  setIntegrations: React.Dispatch<React.SetStateAction<Integration[]>>,
+  setLoadingRootly: (loading: boolean) => void
+): Promise<void> {
+  // Check cache first
+  if (!forceRefresh) {
+    const cachedIntegrations = localStorage.getItem('all_integrations')
+    if (cachedIntegrations) {
+      try {
+        const parsed = JSON.parse(cachedIntegrations)
+        const rootlyIntegrations = parsed.filter((i: Integration) => i.platform === 'rootly')
+        setIntegrations(prev => [
+          ...prev.filter(i => i.platform !== 'rootly'),
+          ...rootlyIntegrations
+        ])
+        setLoadingRootly(false)
+        return
+      } catch (e) {
+        // Cache parse failed, continue to API call
+      }
+    }
+  }
+
+  try {
+    const authToken = localStorage.getItem('auth_token')
+    if (!authToken) return
+
+    const response = await fetch(`${API_BASE}/rootly/integrations`, {
+      headers: { 'Authorization': `Bearer ${authToken}` }
+    })
+
+    const data = response.ok ? await response.json() : { integrations: [] }
+    const rootlyIntegrations = data.integrations.map((i: Integration) => ({ ...i, platform: 'rootly' }))
+
+    setIntegrations(prev => {
+      const updatedIntegrations = [
+        ...prev.filter(i => i.platform !== 'rootly'),
+        ...rootlyIntegrations
+      ]
+
+      // Update cache with fresh data when force refreshing
+      if (forceRefresh) {
+        localStorage.setItem('all_integrations', JSON.stringify(updatedIntegrations))
+        localStorage.setItem('all_integrations_timestamp', Date.now().toString())
+      }
+
+      return updatedIntegrations
+    })
+  } catch (error) {
+    console.error('Error loading Rootly integrations:', error)
+  } finally {
+    setLoadingRootly(false)
+  }
+}
+
+/**
+ * Load PagerDuty integrations with caching
+ */
+export async function loadPagerDutyIntegrations(
+  forceRefresh: boolean,
+  setIntegrations: React.Dispatch<React.SetStateAction<Integration[]>>,
+  setLoadingPagerDuty: (loading: boolean) => void
+): Promise<void> {
+  // Check cache first
+  if (!forceRefresh) {
+    const cachedIntegrations = localStorage.getItem('all_integrations')
+    if (cachedIntegrations) {
+      try {
+        const parsed = JSON.parse(cachedIntegrations)
+        const pagerdutyIntegrations = parsed.filter((i: Integration) => i.platform === 'pagerduty')
+        setIntegrations(prev => [
+          ...prev.filter(i => i.platform !== 'pagerduty'),
+          ...pagerdutyIntegrations
+        ])
+        setLoadingPagerDuty(false)
+        return
+      } catch (e) {
+        // Cache parse failed, continue to API call
+      }
+    }
+  }
+
+  try {
+    const authToken = localStorage.getItem('auth_token')
+    if (!authToken) return
+
+    const response = await fetch(`${API_BASE}/pagerduty/integrations`, {
+      headers: { 'Authorization': `Bearer ${authToken}` }
+    })
+
+    const data = response.ok ? await response.json() : { integrations: [] }
+    const pagerdutyIntegrations = data.integrations || []
+
+    setIntegrations(prev => {
+      const updatedIntegrations = [
+        ...prev.filter(i => i.platform !== 'pagerduty'),
+        ...pagerdutyIntegrations
+      ]
+
+      // Update cache with fresh data when force refreshing
+      if (forceRefresh) {
+        localStorage.setItem('all_integrations', JSON.stringify(updatedIntegrations))
+        localStorage.setItem('all_integrations_timestamp', Date.now().toString())
+      }
+
+      return updatedIntegrations
+    })
+  } catch (error) {
+    console.error('Error loading PagerDuty integrations:', error)
+  } finally {
+    setLoadingPagerDuty(false)
+  }
+}
+
+/**
+ * Add new integration (Rootly or PagerDuty)
+ */
+export async function addIntegration(
+  platform: "rootly" | "pagerduty",
+  previewData: any,
+  form: any,
+  integrations: Integration[],
+  setIsAddingRootly: (loading: boolean) => void,
+  setIsAddingPagerDuty: (loading: boolean) => void,
+  setConnectionStatus: React.Dispatch<React.SetStateAction<"error" | "success" | "idle" | "duplicate">>,
+  setPreviewData: (data: any) => void,
+  setAddingPlatform: React.Dispatch<React.SetStateAction<"rootly" | "pagerduty" | null>>,
+  setReloadingIntegrations: (loading: boolean) => void,
+  loadRootlyIntegrations: (forceRefresh: boolean) => Promise<void>,
+  loadPagerDutyIntegrations: (forceRefresh: boolean) => Promise<void>
+): Promise<void> {
+  if (!previewData) return
+
+  // Set service-specific loading state
+  if (platform === 'rootly') {
+    setIsAddingRootly(true)
+  } else {
+    setIsAddingPagerDuty(true)
+  }
+
+  try {
+    const authToken = localStorage.getItem('auth_token')
+    if (!authToken) {
+      throw new Error('No authentication token found')
+    }
+
+    const values = form.getValues()
+    const token = platform === 'rootly' ? (values as any).rootlyToken : (values as any).pagerdutyToken
+    const nickname = values.nickname
+
+    const endpoint = platform === 'rootly'
+      ? `${API_BASE}/rootly/token/add`
+      : `${API_BASE}/pagerduty/integrations`
+
+    const body = platform === 'rootly'
+      ? {
+          token: token,
+          name: nickname || previewData.suggested_name || previewData.organization_name,
+        }
+      : {
+          token: token,
+          name: nickname || previewData.organization_name,
+          platform: 'pagerduty'
+        }
+
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${authToken}`
+      },
+      body: JSON.stringify(body)
+    })
+
+    const responseData = await response.json()
+
+    if (response.ok) {
+      toast.success(`Your ${platform === 'rootly' ? 'Rootly' : 'PagerDuty'} account has been connected successfully.`)
+
+      // Show loading toast for the reload process
+      const loadingToastId = toast.loading(`Adding ${platform === 'rootly' ? 'Rootly' : 'PagerDuty'} integration to your dashboard...`, {
+        duration: 0 // Persistent until dismissed
+      })
+
+      // Clear local storage cache
+      localStorage.removeItem(`${platform}_integrations`)
+      localStorage.removeItem(`${platform}_integrations_timestamp`)
+      localStorage.removeItem('all_integrations')
+      localStorage.removeItem('all_integrations_timestamp')
+
+      // If this is the first integration, set it as selected for dashboard
+      try {
+        const newIntegrationId = responseData.integration?.id || responseData.id
+        if (newIntegrationId && integrations.length === 0) {
+          localStorage.setItem('selected_organization', newIntegrationId.toString())
+        }
+      } catch (error) {
+        console.error('Error setting default integration:', error)
+        // Continue without setting default - not critical
+      }
+
+      // Reset form and state
+      form.reset()
+      setConnectionStatus('idle')
+      setPreviewData(null)
+      setAddingPlatform(null)
+
+      // Reload integrations to show the newly added one
+      setReloadingIntegrations(true)
+      try {
+        if (platform === 'rootly') {
+          await loadRootlyIntegrations(true)
+        } else {
+          await loadPagerDutyIntegrations(true)
+        }
+
+        // Dismiss loading toast and show success
+        toast.dismiss(loadingToastId)
+        toast.success(`${platform === 'rootly' ? 'Rootly' : 'PagerDuty'} integration added to dashboard!`)
+      } catch (reloadError) {
+        console.error('Error reloading integrations:', reloadError)
+        toast.dismiss(loadingToastId)
+        toast.error('Integration added but failed to refresh list. Please refresh the page.')
+      } finally {
+        setReloadingIntegrations(false)
+      }
+    } else {
+      throw new Error(responseData.detail?.message || responseData.message || 'Failed to add integration')
+    }
+  } catch (error) {
+    console.error('Add integration error:', error)
+    toast.error(error instanceof Error ? error.message : "An unexpected error occurred.")
+  } finally {
+    // Reset service-specific loading state
+    if (platform === 'rootly') {
+      setIsAddingRootly(false)
+    } else {
+      setIsAddingPagerDuty(false)
+    }
+  }
+}
+
+/**
+ * Delete integration
+ */
+export async function deleteIntegration(
+  integrationToDelete: Integration,
+  integrations: Integration[],
+  setIsDeleting: (loading: boolean) => void,
+  setIntegrations: React.Dispatch<React.SetStateAction<Integration[]>>,
+  setDeleteDialogOpen: (open: boolean) => void,
+  setIntegrationToDelete: (integration: Integration | null) => void
+): Promise<void> {
+  setIsDeleting(true)
+  try {
+    const authToken = localStorage.getItem('auth_token')
+    if (!authToken) return
+
+    const endpoint = integrationToDelete.platform === 'rootly'
+      ? `${API_BASE}/rootly/integrations/${integrationToDelete.id}`
+      : `${API_BASE}/pagerduty/integrations/${integrationToDelete.id}`
+
+    const response = await fetch(endpoint, {
+      method: 'DELETE',
+      headers: {
+        'Authorization': `Bearer ${authToken}`
+      }
+    })
+
+    if (response.ok) {
+      toast.success("The integration has been removed.")
+
+      // Optimized: Update local state directly instead of full reload
+      const updatedIntegrations = integrations.filter(i => i.id !== integrationToDelete.id)
+      setIntegrations(updatedIntegrations)
+
+      // Update cache with filtered results
+      localStorage.setItem('all_integrations', JSON.stringify(updatedIntegrations))
+      localStorage.setItem('all_integrations_timestamp', Date.now().toString())
+
+      // Clear platform-specific cache
+      localStorage.removeItem(`${integrationToDelete.platform}_integrations`)
+      localStorage.removeItem(`${integrationToDelete.platform}_integrations_timestamp`)
+
+      // If we deleted the currently selected integration, clear the selection
+      const selectedOrg = localStorage.getItem('selected_organization')
+      if (selectedOrg === integrationToDelete.id.toString()) {
+        localStorage.removeItem('selected_organization')
+      }
+
+      setDeleteDialogOpen(false)
+      setIntegrationToDelete(null)
+    } else {
+      throw new Error('Failed to delete integration')
+    }
+  } catch (error) {
+    console.error('Delete error:', error)
+    toast.error("An error occurred while deleting the integration.")
+  } finally {
+    setIsDeleting(false)
+  }
+}
+
+/**
+ * Update integration name
+ */
+export async function updateIntegrationName(
+  integration: Integration,
+  newName: string,
+  setSavingIntegrationId: (id: number | null) => void,
+  setIntegrations: React.Dispatch<React.SetStateAction<Integration[]>>,
+  setEditingIntegration: (id: number | null) => void
+): Promise<void> {
+  setSavingIntegrationId(integration.id)
+  try {
+    const authToken = localStorage.getItem('auth_token')
+    if (!authToken) return
+
+    const endpoint = integration.platform === 'rootly'
+      ? `${API_BASE}/rootly/integrations/${integration.id}`
+      : `${API_BASE}/pagerduty/integrations/${integration.id}`
+
+    const response = await fetch(endpoint, {
+      method: 'PUT',
+      headers: {
+        'Authorization': `Bearer ${authToken}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ name: newName })
+    })
+
+    if (response.ok) {
+      toast.success("Integration name updated successfully")
+
+      // Update local state
+      setIntegrations(prev => prev.map(i =>
+        i.id === integration.id ? { ...i, name: newName } : i
+      ))
+
+      // Update cache
+      const cachedIntegrations = localStorage.getItem('all_integrations')
+      if (cachedIntegrations) {
+        try {
+          const parsed = JSON.parse(cachedIntegrations)
+          const updated = parsed.map((i: Integration) =>
+            i.id === integration.id ? { ...i, name: newName } : i
+          )
+          localStorage.setItem('all_integrations', JSON.stringify(updated))
+        } catch (e) {
+          // If cache update fails, just clear it
+          localStorage.removeItem('all_integrations')
+        }
+      }
+
+      setEditingIntegration(null)
+    } else {
+      throw new Error('Failed to update integration name')
+    }
+  } catch (error) {
+    console.error('Update error:', error)
+    toast.error("Failed to update integration name")
+  } finally {
+    setSavingIntegrationId(null)
+  }
+}

--- a/frontend/src/app/integrations/handlers/mapping-handlers.ts
+++ b/frontend/src/app/integrations/handlers/mapping-handlers.ts
@@ -1,0 +1,514 @@
+import { toast } from "sonner"
+import { API_BASE, IntegrationMapping, MappingStatistics } from "../types"
+
+export async function loadMappingData(
+  platform: 'github' | 'slack',
+  showMappingDialog: boolean,
+  setLoadingMappingData: (loading: boolean) => void,
+  setSelectedMappingPlatform: (platform: 'github' | 'slack') => void,
+  setMappingData: (data: IntegrationMapping[]) => void,
+  setMappingStats: (stats: MappingStatistics) => void,
+  setAnalysisMappingStats: (stats: any) => void,
+  setCurrentAnalysisId: (id: number | null) => void,
+  setShowMappingDialog: (show: boolean) => void
+): Promise<void> {
+  setLoadingMappingData(true)
+  setSelectedMappingPlatform(platform)
+
+  try {
+    const authToken = localStorage.getItem('auth_token')
+    if (!authToken) {
+      toast.error('Please log in to view mapping data')
+      return
+    }
+
+    // Use the existing working endpoints
+
+    const [mappingsResponse, statsResponse] = await Promise.all([
+      fetch(`${API_BASE}/integrations/mappings/platform/${platform}`, {
+        headers: { 'Authorization': `Bearer ${authToken}` }
+      }),
+      fetch(`${API_BASE}/integrations/mappings/success-rate?platform=${platform}`, {
+        headers: { 'Authorization': `Bearer ${authToken}` }
+      })
+    ])
+
+
+    if (mappingsResponse.ok && statsResponse.ok) {
+      const mappings = await mappingsResponse.json()
+      const stats = await statsResponse.json()
+
+      const failedMappings = mappings.filter(m => !m.target_identifier)
+      const successfulMappings = mappings.filter(m => m.target_identifier)
+
+
+      setMappingData(mappings)
+      setMappingStats(stats)
+      setAnalysisMappingStats(null)
+      setCurrentAnalysisId(null)
+      setShowMappingDialog(true)
+
+
+      // Show success message only if dialog is already open (refresh action)
+      if (showMappingDialog) {
+        toast.success(`${platform === 'github' ? 'GitHub' : 'Slack'} mapping data refreshed successfully`)
+      }
+    } else {
+      throw new Error(`Failed to fetch mapping data - Mappings: ${mappingsResponse.status}, Stats: ${statsResponse.status}`)
+    }
+  } catch (error) {
+    toast.error(`Failed to load mapping data: ${error.message}`)
+  } finally {
+    setLoadingMappingData(false)
+  }
+}
+
+export async function validateGithubUsername(
+  username: string,
+  setValidatingGithub: (loading: boolean) => void,
+  setGithubValidation: (validation: { valid: boolean; message: string } | null) => void
+): Promise<boolean> {
+  if (!username.trim()) {
+    setGithubValidation({ valid: false, message: 'Username cannot be empty' })
+    return false
+  }
+
+  setValidatingGithub(true)
+  try {
+    const authToken = localStorage.getItem('auth_token')
+    if (!authToken) {
+      setGithubValidation({ valid: false, message: 'Not authenticated' })
+      return false
+    }
+
+    const response = await fetch(`${API_BASE}/integrations/mappings/github/validate/${encodeURIComponent(username.trim())}`, {
+      headers: { 'Authorization': `Bearer ${authToken}` }
+    })
+
+    const data = await response.json()
+
+    if (response.ok && data.valid) {
+      setGithubValidation({ valid: true, message: `Found: ${data.name || data.username}` })
+      return true
+    } else {
+      const errorMsg = data.message || data.error || `API Error (${response.status})`
+      setGithubValidation({ valid: false, message: errorMsg })
+      return false
+    }
+  } catch (error) {
+    console.error('Error validating GitHub username:', error)
+    setGithubValidation({ valid: false, message: 'Validation failed' })
+    return false
+  } finally {
+    setValidatingGithub(false)
+  }
+}
+
+export async function saveEditedMapping(
+  mappingId: number | string,
+  email: string,
+  inlineEditingValue: string,
+  selectedMappingPlatform: 'github' | 'slack' | null,
+  githubValidation: { valid: boolean; message?: string } | null,
+  setSavingInlineMapping: (saving: boolean) => void,
+  setMappingData: React.Dispatch<React.SetStateAction<any[]>>,
+  setInlineEditingId: (id: number | string | null) => void,
+  setInlineEditingValue: (value: string) => void,
+  setGithubValidation: (validation: { valid: boolean; message?: string } | null) => void,
+  validateGithubUsername: (username: string) => Promise<boolean>
+): Promise<void> {
+  if (!inlineEditingValue.trim()) {
+    toast.error('Please enter a valid username')
+    return
+  }
+
+  const authToken = localStorage.getItem('auth_token')
+  if (!authToken) {
+    toast.error('Please log in to edit mappings')
+    return
+  }
+
+  // Validate GitHub username first (for both manual and auto mappings)
+  if (selectedMappingPlatform === 'github') {
+    if (!githubValidation || githubValidation.valid !== true) {
+      const isValid = await validateGithubUsername(inlineEditingValue)
+      if (!isValid) {
+        toast.error(`Invalid GitHub username: ${githubValidation?.message || 'User not found'}`, {
+          duration: 4000
+        })
+        return
+      }
+    }
+  }
+
+  // Handle manual mappings differently (use UserMapping endpoint during migration period)
+  if (typeof mappingId === 'string' && mappingId.startsWith('manual_')) {
+    // Extract the numeric ID from "manual_123" format
+    const numericId = parseInt(mappingId.replace('manual_', ''))
+
+    setSavingInlineMapping(true)
+    try {
+      // Use the manual mappings endpoint instead
+      const response = await fetch(`${API_BASE}/integrations/manual-mappings/${numericId}`, {
+        method: 'PUT',
+        headers: {
+          'Authorization': `Bearer ${authToken}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          target_identifier: inlineEditingValue.trim()
+        })
+      })
+
+      if (response.ok) {
+        const result = await response.json()
+        toast.success(`Successfully updated manual mapping to '${inlineEditingValue}'`)
+
+        // Update the local mapping data
+        setMappingData(prevData =>
+          prevData.map(m =>
+            m.id === mappingId
+              ? { ...m, target_identifier: inlineEditingValue.trim(), mapping_successful: true }
+              : m
+          )
+        )
+
+        // Clear editing state
+        setInlineEditingId(null)
+        setInlineEditingValue('')
+        setGithubValidation(null)
+        return
+      } else {
+        const errorData = await response.json()
+        toast.error(errorData.detail || 'Failed to update manual mapping')
+        return
+      }
+    } catch (error) {
+      console.error('Manual mapping edit error:', error)
+      toast.error('Failed to update manual mapping')
+      return
+    } finally {
+      setSavingInlineMapping(false)
+    }
+  }
+
+  setSavingInlineMapping(true)
+  try {
+
+    const response = await fetch(`${API_BASE}/integrations/mappings/${mappingId}/edit?new_target_identifier=${encodeURIComponent(inlineEditingValue.trim())}`, {
+      method: 'PUT',
+      headers: {
+        'Authorization': `Bearer ${authToken}`,
+        'Content-Type': 'application/json'
+      }
+    })
+
+    if (response.ok) {
+      const result = await response.json()
+      toast.success(result.message || `Successfully updated mapping to '${inlineEditingValue}'`)
+
+      // Update the local mapping data
+      setMappingData(prevData =>
+        prevData.map(m =>
+          m.id === mappingId
+            ? {
+                ...m,
+                target_identifier: inlineEditingValue.trim(),
+                mapping_successful: true,
+                is_manual: true,  // It becomes manual after editing
+                source: 'manual',
+                mapping_method: 'manual_edit',
+                last_updated: new Date().toISOString()
+              }
+            : m
+        )
+      )
+
+      // Clear editing state
+      setInlineEditingId(null)
+      setInlineEditingValue('')
+      setGithubValidation(null)
+    } else {
+      const errorData = await response.json()
+      toast.error(errorData.message || 'Failed to update mapping')
+    }
+  } catch (error) {
+    console.error('Error updating mapping:', error)
+    toast.error('Failed to update mapping')
+  } finally {
+    setSavingInlineMapping(false)
+  }
+}
+
+export async function saveInlineMapping(
+  mappingId: number | string,
+  email: string,
+  inlineEditingValue: string,
+  selectedMappingPlatform: 'github' | 'slack' | null,
+  githubValidation: { valid: boolean; message?: string } | null,
+  setSavingInlineMapping: (saving: boolean) => void,
+  setMappingData: React.Dispatch<React.SetStateAction<any[]>>,
+  setInlineEditingId: (id: number | string | null) => void,
+  setInlineEditingValue: (value: string) => void,
+  validateGithubUsername: (username: string) => Promise<boolean>
+): Promise<void> {
+  // Skip manual mappings - they can't be edited inline as they already exist
+  if (typeof mappingId === 'string' && mappingId.startsWith('manual_')) {
+    toast.error('Manual mappings cannot be edited inline')
+    return
+  }
+  if (!inlineEditingValue.trim()) {
+    toast.error('Please enter a GitHub username')
+    return
+  }
+
+  // Validate GitHub username first
+  if (selectedMappingPlatform === 'github') {
+    // If we haven't validated yet or validation failed, validate now
+    if (!githubValidation || githubValidation.valid !== true) {
+      const isValid = await validateGithubUsername(inlineEditingValue)
+      if (!isValid) {
+        toast.error(`Invalid GitHub username: ${githubValidation?.message || 'User not found'}`, {
+          duration: 4000
+        })
+        return
+      }
+    }
+  }
+
+  setSavingInlineMapping(true)
+  try {
+    const authToken = localStorage.getItem('auth_token')
+    if (!authToken) {
+      toast.error('Please log in to save mappings')
+      return
+    }
+
+    const response = await fetch(`${API_BASE}/integrations/manual-mappings`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${authToken}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        source_platform: 'rootly',
+        source_identifier: email,
+        target_platform: selectedMappingPlatform,
+        target_identifier: inlineEditingValue.trim()
+      })
+    })
+
+    if (response.ok) {
+      toast.success(`Manual mapping saved: ${email} → ${inlineEditingValue}`)
+
+      // Update the local mapping data to show the change immediately
+      setMappingData(prevData =>
+        prevData.map(m =>
+          m.id === mappingId
+            ? {
+                ...m,
+                target_identifier: inlineEditingValue.trim(),
+                mapping_successful: true,
+                error_message: null,
+                mapping_method: 'manual'
+              }
+            : m
+        )
+      )
+
+      // Reset inline editing state
+      setInlineEditingId(null)
+      setInlineEditingValue('')
+
+      // Note: The manual mapping is saved but won't show in IntegrationMapping
+      // until the next analysis is run
+      toast.info('Manual mapping saved. Run a new analysis to use this mapping.', {
+        duration: 5000
+      })
+    } else {
+      const error = await response.json()
+      toast.error(`Failed to save mapping: ${error.detail || 'Unknown error'}`)
+    }
+  } catch (error) {
+    console.error('Error saving manual mapping:', error)
+    toast.error('Failed to save mapping')
+  } finally {
+    setSavingInlineMapping(false)
+  }
+}
+
+export async function loadManualMappings(
+  platform: 'github' | 'slack',
+  setLoadingManualMappings: (loading: boolean) => void,
+  setSelectedManualMappingPlatform: (platform: 'github' | 'slack' | null) => void,
+  setManualMappings: (mappings: any[]) => void,
+  setManualMappingStats: (stats: any) => void,
+  setShowManualMappingDialog: (show: boolean) => void
+): Promise<void> {
+  try {
+    setLoadingManualMappings(true)
+    setSelectedManualMappingPlatform(platform)
+
+    const authToken = localStorage.getItem('auth_token')
+    if (!authToken) {
+      toast.error('Please log in to view manual mappings')
+      return
+    }
+
+    const [mappingsResponse, statsResponse] = await Promise.all([
+      fetch(`${API_BASE}/integrations/manual-mappings?target_platform=${platform}`, {
+        headers: {
+          'Authorization': `Bearer ${authToken}`,
+          'Content-Type': 'application/json'
+        }
+      }),
+      fetch(`${API_BASE}/integrations/manual-mappings/statistics`, {
+        headers: {
+          'Authorization': `Bearer ${authToken}`,
+          'Content-Type': 'application/json'
+        }
+      })
+    ])
+
+    if (mappingsResponse.ok && statsResponse.ok) {
+      const mappingsData = await mappingsResponse.json()
+      const statsData = await statsResponse.json()
+
+      setManualMappings(mappingsData)
+      setManualMappingStats(statsData)
+      setShowManualMappingDialog(true)
+    } else {
+      toast.error('Failed to load manual mappings')
+    }
+  } catch (error) {
+    console.error('Error loading manual mappings:', error)
+    toast.error('Failed to load manual mappings')
+  } finally {
+    setLoadingManualMappings(false)
+  }
+}
+
+export async function createManualMapping(
+  newMappingForm: any,
+  showManualMappingDialog: boolean,
+  selectedManualMappingPlatform: 'github' | 'slack' | null,
+  setNewMappingDialogOpen: (open: boolean) => void,
+  setNewMappingForm: (form: any) => void,
+  loadManualMappings: (platform: 'github' | 'slack') => Promise<void>
+): Promise<void> {
+  try {
+    const authToken = localStorage.getItem('auth_token')
+    if (!authToken) {
+      toast.error('Please log in to create mappings')
+      return
+    }
+
+    const response = await fetch(`${API_BASE}/integrations/manual-mappings`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${authToken}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(newMappingForm)
+    })
+
+    if (response.ok) {
+      toast.success('Manual mapping created successfully')
+      // Reload mappings if dialog is open
+      if (showManualMappingDialog && selectedManualMappingPlatform) {
+        loadManualMappings(selectedManualMappingPlatform)
+      }
+      setNewMappingDialogOpen(false)
+      setNewMappingForm({
+        source_platform: 'rootly',
+        source_identifier: '',
+        target_platform: selectedManualMappingPlatform || 'github',
+        target_identifier: ''
+      })
+    } else {
+      const errorData = await response.json()
+      toast.error(errorData.detail || 'Failed to create mapping')
+    }
+  } catch (error) {
+    console.error('Error creating manual mapping:', error)
+    toast.error('Failed to create mapping')
+  }
+}
+
+export async function updateManualMapping(
+  mappingId: number,
+  targetIdentifier: string,
+  showManualMappingDialog: boolean,
+  selectedManualMappingPlatform: 'github' | 'slack' | null,
+  setEditingMapping: (mapping: any) => void,
+  loadManualMappings: (platform: 'github' | 'slack') => Promise<void>
+): Promise<void> {
+  try {
+    const authToken = localStorage.getItem('auth_token')
+    if (!authToken) {
+      toast.error('Please log in to update mappings')
+      return
+    }
+
+    const response = await fetch(`${API_BASE}/integrations/manual-mappings/${mappingId}`, {
+      method: 'PUT',
+      headers: {
+        'Authorization': `Bearer ${authToken}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ target_identifier: targetIdentifier })
+    })
+
+    if (response.ok) {
+      toast.success('Manual mapping updated successfully')
+      // Reload mappings
+      if (showManualMappingDialog && selectedManualMappingPlatform) {
+        loadManualMappings(selectedManualMappingPlatform)
+      }
+      setEditingMapping(null)
+    } else {
+      const errorData = await response.json()
+      toast.error(errorData.detail || 'Failed to update mapping')
+    }
+  } catch (error) {
+    console.error('Error updating manual mapping:', error)
+    toast.error('Failed to update mapping')
+  }
+}
+
+export async function deleteManualMapping(
+  mappingId: number,
+  showManualMappingDialog: boolean,
+  selectedManualMappingPlatform: 'github' | 'slack' | null,
+  loadManualMappings: (platform: 'github' | 'slack') => Promise<void>
+): Promise<void> {
+  try {
+    const authToken = localStorage.getItem('auth_token')
+    if (!authToken) {
+      toast.error('Please log in to delete mappings')
+      return
+    }
+
+    const response = await fetch(`${API_BASE}/integrations/manual-mappings/${mappingId}`, {
+      method: 'DELETE',
+      headers: {
+        'Authorization': `Bearer ${authToken}`,
+        'Content-Type': 'application/json'
+      }
+    })
+
+    if (response.ok) {
+      toast.success('Manual mapping deleted successfully')
+      // Reload mappings
+      if (showManualMappingDialog && selectedManualMappingPlatform) {
+        loadManualMappings(selectedManualMappingPlatform)
+      }
+    } else {
+      const errorData = await response.json()
+      toast.error(errorData.detail || 'Failed to delete mapping')
+    }
+  } catch (error) {
+    console.error('Error deleting manual mapping:', error)
+    toast.error('Failed to delete mapping')
+  }
+}

--- a/frontend/src/app/integrations/handlers/organization-handlers.ts
+++ b/frontend/src/app/integrations/handlers/organization-handlers.ts
@@ -1,0 +1,158 @@
+import { toast } from "sonner"
+import { API_BASE } from "../types"
+
+/**
+ * Send invitation to new organization member
+ */
+export async function handleInvite(
+  inviteEmail: string,
+  inviteRole: string,
+  setIsInviting: (loading: boolean) => void,
+  setInviteEmail: (email: string) => void,
+  setInviteRole: (role: string) => void,
+  setShowInviteModal: (show: boolean) => void,
+  loadOrganizationData: () => Promise<void>
+): Promise<void> {
+  if (!inviteEmail.trim()) {
+    toast.error("Please enter an email address")
+    return
+  }
+
+  setIsInviting(true)
+  try {
+    const authToken = localStorage.getItem('auth_token')
+    if (!authToken) {
+      toast.error("Authentication required")
+      return
+    }
+
+    const apiUrl = `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/invitations/create`
+
+    const response = await fetch(apiUrl, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${authToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        email: inviteEmail.trim(),
+        role: inviteRole
+      })
+    })
+
+    if (!response.ok) {
+      const responseText = await response.text()
+
+      // Try to parse as JSON, fallback to text
+      let errorMessage = 'Failed to send invitation'
+      try {
+        const errorData = JSON.parse(responseText)
+        errorMessage = errorData.detail || errorMessage
+      } catch {
+        errorMessage = responseText.includes('<!DOCTYPE')
+          ? 'API server not available or wrong URL'
+          : responseText
+      }
+
+      throw new Error(errorMessage)
+    }
+
+    const data = await response.json()
+    toast.success(`Invitation sent to ${inviteEmail}! They'll receive a notification and can accept within 30 days.`)
+
+    // Reset form and refresh organization data
+    setInviteEmail("")
+    setInviteRole("member")
+    setShowInviteModal(false)
+
+    // Refresh the organization data to show the new invitation
+    await loadOrganizationData()
+
+  } catch (error) {
+    console.error('Failed to send invitation:', error)
+    toast.error(error instanceof Error ? error.message : "Failed to send invitation")
+  } finally {
+    setIsInviting(false)
+  }
+}
+
+/**
+ * Update role for organization member
+ */
+export async function handleRoleChange(
+  userId: number,
+  newRole: string,
+  loadOrganizationData: () => Promise<void>
+): Promise<void> {
+  const authToken = localStorage.getItem('auth_token')
+  if (!authToken) {
+    toast.error("Authentication required")
+    return
+  }
+
+  try {
+    const response = await fetch(`${API_BASE}/api/auth/users/${userId}/role?new_role=${newRole}`, {
+      method: 'PATCH',
+      headers: {
+        'Authorization': `Bearer ${authToken}`,
+      }
+    })
+
+    if (response.ok) {
+      const data = await response.json()
+      toast.success(data.message || `Role updated successfully`)
+      // Reload organization data to reflect the change
+      await loadOrganizationData()
+    } else {
+      const errorData = await response.json()
+      throw new Error(errorData.detail || 'Failed to update role')
+    }
+  } catch (error) {
+    console.error('Failed to update role:', error)
+    toast.error(error instanceof Error ? error.message : 'Failed to update role')
+  }
+}
+
+/**
+ * Load organization members and pending invitations
+ */
+export async function loadOrganizationData(
+  setLoadingOrgData: (loading: boolean) => void,
+  setOrgMembers: (members: any[]) => void,
+  setPendingInvitations: (invitations: any[]) => void
+): Promise<void> {
+  const authToken = localStorage.getItem('auth_token')
+  if (!authToken) return
+
+  setLoadingOrgData(true)
+  try {
+    // Load organization members
+    const membersResponse = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/api/invitations/organization/members`, {
+      headers: {
+        'Authorization': `Bearer ${authToken}`,
+      }
+    })
+
+    if (membersResponse.ok) {
+      const membersData = await membersResponse.json()
+      setOrgMembers(membersData.members || [])
+    }
+
+    // Load pending invitations
+    const invitationsResponse = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/api/invitations/pending`, {
+      headers: {
+        'Authorization': `Bearer ${authToken}`,
+      }
+    })
+
+    if (invitationsResponse.ok) {
+      const invitationsData = await invitationsResponse.json()
+      setPendingInvitations(invitationsData.invitations || [])
+    }
+
+  } catch (error) {
+    console.error('Failed to load organization data:', error)
+  } finally {
+    setLoadingOrgData(false)
+  }
+}

--- a/frontend/src/app/integrations/handlers/slack-handlers.ts
+++ b/frontend/src/app/integrations/handlers/slack-handlers.ts
@@ -1,0 +1,205 @@
+import { toast } from "sonner"
+import { type SlackIntegration, API_BASE } from "../types"
+
+/**
+ * Load Slack integration from API with caching
+ */
+export async function loadSlackIntegration(
+  forceRefresh: boolean,
+  setSlackIntegration: (integration: SlackIntegration | null) => void,
+  setLoadingSlack: (loading: boolean) => void
+): Promise<void> {
+  if (!forceRefresh) {
+    const cached = localStorage.getItem('slack_integration')
+    if (cached) {
+      try {
+        const slackData = JSON.parse(cached)
+        setSlackIntegration(slackData.integration)
+        setLoadingSlack(false)
+        return
+      } catch (e) {
+        // Cache parse failed, continue to API call
+      }
+    }
+  }
+
+  try {
+    const authToken = localStorage.getItem('auth_token')
+    if (!authToken) return
+
+    const response = await fetch(`${API_BASE}/integrations/slack/status`, {
+      headers: { 'Authorization': `Bearer ${authToken}` }
+    })
+
+    const slackData = response.ok ? await response.json() : { integration: null }
+
+    setSlackIntegration(slackData.integration)
+    localStorage.setItem('slack_integration', JSON.stringify(slackData))
+  } catch (error) {
+    console.error('Error loading Slack integration:', error)
+  } finally {
+    setLoadingSlack(false)
+  }
+}
+
+/**
+ * Connect Slack integration with webhook and bot token
+ */
+export async function handleSlackConnect(
+  webhookUrl: string,
+  botToken: string,
+  setIsConnectingSlack: (loading: boolean) => void,
+  setSlackWebhookUrl: (url: string) => void,
+  setSlackBotToken: (token: string) => void,
+  setActiveEnhancementTab: (tab: "github" | "slack" | null) => void,
+  loadSlackIntegration: (forceRefresh: boolean) => void
+): Promise<void> {
+  setIsConnectingSlack(true)
+  try {
+    const authToken = localStorage.getItem('auth_token')
+    if (!authToken) {
+      throw new Error('No authentication token found')
+    }
+
+    const response = await fetch(`${API_BASE}/integrations/slack/setup`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${authToken}`
+      },
+      body: JSON.stringify({
+        webhook_url: webhookUrl,
+        token: botToken
+      })
+    })
+
+    if (!response.ok) {
+      const errorData = await response.json()
+      throw new Error(errorData.detail || 'Failed to connect Slack')
+    }
+
+    toast.success("Your Slack workspace has been connected successfully.")
+
+    setSlackWebhookUrl('')
+    setSlackBotToken('')
+    setActiveEnhancementTab(null)
+    loadSlackIntegration(true)
+  } catch (error) {
+    console.error('Error connecting Slack:', error)
+    toast.error(error instanceof Error ? error.message : "An unexpected error occurred.")
+  } finally {
+    setIsConnectingSlack(false)
+  }
+}
+
+/**
+ * Disconnect Slack integration
+ */
+export async function handleSlackDisconnect(
+  setIsDisconnectingSlack: (loading: boolean) => void,
+  setSlackDisconnectDialogOpen: (open: boolean) => void,
+  loadSlackIntegration: (forceRefresh: boolean) => void
+): Promise<void> {
+  setIsDisconnectingSlack(true)
+  try {
+    const authToken = localStorage.getItem('auth_token')
+    if (!authToken) return
+
+    const response = await fetch(`${API_BASE}/integrations/slack/disconnect`, {
+      method: 'DELETE',
+      headers: {
+        'Authorization': `Bearer ${authToken}`
+      }
+    })
+
+    if (response.ok) {
+      toast.success("Your Slack integration has been removed.")
+      setSlackDisconnectDialogOpen(false)
+      loadSlackIntegration(true) // Force refresh after changes
+    }
+  } catch (error) {
+    console.error('Error disconnecting Slack:', error)
+    toast.error(error instanceof Error ? error.message : "An unexpected error occurred.")
+  } finally {
+    setIsDisconnectingSlack(false)
+  }
+}
+
+/**
+ * Test Slack connection and permissions
+ */
+export async function handleSlackTest(
+  setSlackPermissions: (permissions: any) => void,
+  setSlackIntegration: React.Dispatch<React.SetStateAction<SlackIntegration | null>>
+): Promise<void> {
+  try {
+    const authToken = localStorage.getItem('auth_token')
+    if (!authToken) {
+      toast.error("Please log in to test your Slack integration.")
+      return
+    }
+
+    toast.info("Testing Slack connection...")
+
+    const response = await fetch(`${API_BASE}/integrations/slack/test`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${authToken}`
+      }
+    })
+
+    if (response.ok) {
+      const data = await response.json()
+      setSlackPermissions(data.permissions)
+
+      // Store channels list if available
+      if (data.channels) {
+        setSlackIntegration(prev => prev ? {...prev, channels: data.channels} : null)
+      }
+
+      const workspaceName = data.workspace_info?.team_name || 'your workspace'
+      const userName = data.user_info?.name || 'Slack user'
+
+      toast.success(`✅ Slack test successful! Connected as ${userName} in ${workspaceName}. Permissions updated.`)
+    } else {
+      const errorData = await response.json().catch(() => ({}))
+      throw new Error(errorData.detail || 'Connection test failed')
+    }
+  } catch (error) {
+    console.error('Error testing Slack connection:', error)
+    toast.error(`❌ Slack test failed: ${error instanceof Error ? error.message : "Unable to test Slack connection."}`)
+  }
+}
+
+/**
+ * Load Slack permissions
+ */
+export async function loadSlackPermissions(
+  slackIntegration: SlackIntegration | null,
+  setIsLoadingPermissions: (loading: boolean) => void,
+  setSlackPermissions: (permissions: any) => void
+): Promise<void> {
+  if (!slackIntegration) return
+
+  setIsLoadingPermissions(true)
+  try {
+    const authToken = localStorage.getItem('auth_token')
+    if (!authToken) return
+
+    const response = await fetch(`${API_BASE}/integrations/slack/test`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${authToken}`
+      }
+    })
+
+    if (response.ok) {
+      const data = await response.json()
+      setSlackPermissions(data.permissions)
+    }
+  } catch (error) {
+    console.error('Error loading Slack permissions:', error)
+  } finally {
+    setIsLoadingPermissions(false)
+  }
+}

--- a/frontend/src/app/integrations/handlers/team-handlers.ts
+++ b/frontend/src/app/integrations/handlers/team-handlers.ts
@@ -1,0 +1,225 @@
+import { toast } from "sonner"
+import { API_BASE } from "../types"
+
+/**
+ * Fetch team members from selected organization
+ */
+export async function fetchTeamMembers(
+  selectedOrganization: string,
+  setLoadingTeamMembers: (loading: boolean) => void,
+  setTeamMembersError: (error: string | null) => void,
+  setTeamMembers: (members: any[]) => void,
+  setTeamMembersDrawerOpen: (open: boolean) => void
+): Promise<void> {
+  if (!selectedOrganization) {
+    toast.error('Please select an organization first')
+    return
+  }
+  setLoadingTeamMembers(true)
+  setTeamMembersError(null)
+
+  try {
+    const authToken = localStorage.getItem('auth_token')
+    if (!authToken) {
+      toast.error('Please log in to view team members')
+      return
+    }
+
+    const response = await fetch(`${API_BASE}/rootly/integrations/${selectedOrganization}/users`, {
+      headers: {
+        'Authorization': `Bearer ${authToken}`,
+        'Content-Type': 'application/json'
+      }
+    })
+
+    if (response.ok) {
+      const data = await response.json()
+      setTeamMembers(data.users || [])
+      setTeamMembersDrawerOpen(true)
+      toast.success(`Loaded ${data.total_users} team members from ${data.integration_name}`)
+    } else {
+      const errorData = await response.json()
+      throw new Error(errorData.detail || 'Failed to fetch team members')
+    }
+  } catch (error) {
+    console.error('Error fetching team members:', error)
+    const errorMsg = error instanceof Error ? error.message : 'Failed to fetch team members'
+    setTeamMembersError(errorMsg)
+    toast.error(errorMsg)
+  } finally {
+    setLoadingTeamMembers(false)
+  }
+}
+
+/**
+ * Sync users to UserCorrelation table
+ */
+export async function syncUsersToCorrelation(
+  selectedOrganization: string,
+  setLoadingTeamMembers: (loading: boolean) => void,
+  setTeamMembersError: (error: string | null) => void,
+  fetchTeamMembers: () => Promise<void>,
+  fetchSyncedUsers: (showToast?: boolean, autoSync?: boolean) => Promise<void>
+): Promise<void> {
+  if (!selectedOrganization) {
+    toast.error('Please select an organization first')
+    return
+  }
+  setLoadingTeamMembers(true)
+  setTeamMembersError(null)
+
+  try {
+    const authToken = localStorage.getItem('auth_token')
+    if (!authToken) {
+      toast.error('Please log in to sync users')
+      return
+    }
+
+    const response = await fetch(`${API_BASE}/rootly/integrations/${selectedOrganization}/sync-users`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${authToken}`,
+        'Content-Type': 'application/json'
+      }
+    })
+
+    if (response.ok) {
+      const data = await response.json()
+      const stats = data.stats || data
+      toast.success(
+        `Synced ${stats.created} new users, updated ${stats.updated} existing users. ` +
+        `All team members can now submit burnout surveys via Slack!`
+      )
+      // Reload the members list and fetch synced users (without showing another toast or auto-syncing again)
+      await fetchTeamMembers()
+      await fetchSyncedUsers(false, false)
+    } else {
+      const errorData = await response.json()
+      throw new Error(errorData.detail || 'Failed to sync users')
+    }
+  } catch (error) {
+    console.error('Error syncing users:', error)
+    const errorMsg = error instanceof Error ? error.message : 'Failed to sync users'
+    setTeamMembersError(errorMsg)
+    toast.error(errorMsg)
+  } finally {
+    setLoadingTeamMembers(false)
+  }
+}
+
+/**
+ * Sync Slack user IDs to UserCorrelation records
+ */
+export async function syncSlackUserIds(
+  setLoadingTeamMembers: (loading: boolean) => void,
+  fetchSyncedUsers: (showToast?: boolean, autoSync?: boolean) => Promise<void>
+): Promise<void> {
+  setLoadingTeamMembers(true)
+
+  try {
+    const authToken = localStorage.getItem('auth_token')
+    if (!authToken) {
+      toast.error('Please log in to sync Slack user IDs')
+      return
+    }
+
+    const response = await fetch(`${API_BASE}/integrations/slack/sync-user-ids`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${authToken}`,
+        'Content-Type': 'application/json'
+      }
+    })
+
+    if (response.ok) {
+      const data = await response.json()
+      const stats = data.stats || {}
+      toast.success(
+        `Synced Slack IDs for ${stats.updated} users! ` +
+        `${stats.skipped} users skipped (no matching Slack account).`
+      )
+      // Refresh synced users list
+      await fetchSyncedUsers(false)
+    } else {
+      const errorData = await response.json()
+      throw new Error(errorData.detail || 'Failed to sync Slack user IDs')
+    }
+  } catch (error) {
+    console.error('Error syncing Slack user IDs:', error)
+    const errorMsg = error instanceof Error ? error.message : 'Failed to sync Slack user IDs'
+    toast.error(errorMsg)
+  } finally {
+    setLoadingTeamMembers(false)
+  }
+}
+
+/**
+ * Fetch synced users from database
+ */
+export async function fetchSyncedUsers(
+  selectedOrganization: string,
+  setLoadingSyncedUsers: (loading: boolean) => void,
+  setSyncedUsers: (users: any[]) => void,
+  setShowSyncedUsers: (show: boolean) => void,
+  setTeamMembersDrawerOpen: (open: boolean) => void,
+  syncUsersToCorrelation: () => Promise<void>,
+  showToast: boolean = true,
+  autoSync: boolean = true
+): Promise<void> {
+  if (!selectedOrganization) {
+    toast.error('Please select an organization first')
+    return
+  }
+
+  setLoadingSyncedUsers(true)
+
+  try {
+    const authToken = localStorage.getItem('auth_token')
+    if (!authToken) {
+      toast.error('Please log in to view synced users')
+      return
+    }
+
+    const response = await fetch(`${API_BASE}/rootly/synced-users?integration_id=${selectedOrganization}`, {
+      headers: {
+        'Authorization': `Bearer ${authToken}`,
+        'Content-Type': 'application/json'
+      }
+    })
+
+    if (response.ok) {
+      const data = await response.json()
+      const users = data.users || []
+      setSyncedUsers(users)
+      setShowSyncedUsers(true)
+      setTeamMembersDrawerOpen(true)
+
+      // If no users found, automatically sync them (but not for beta integrations)
+      // Only auto-sync once to prevent infinite loops
+      if (users.length === 0 && !selectedOrganization.startsWith('beta-') && autoSync) {
+        toast.info('No synced users found. Syncing now...')
+        setLoadingSyncedUsers(false) // Reset loading state before syncing
+        await syncUsersToCorrelation()
+        // syncUsersToCorrelation will call fetchSyncedUsers again after syncing
+        return
+      }
+
+      if (showToast) {
+        if (users.length === 0) {
+          toast.info('Beta integrations show users from shared access. Use "Sync Members" with your own integration to enable survey submissions.')
+        } else {
+          toast.success(`Found ${data.total} synced users`)
+        }
+      }
+    } else {
+      const errorData = await response.json()
+      throw new Error(errorData.detail || 'Failed to fetch synced users')
+    }
+  } catch (error) {
+    console.error('Error fetching synced users:', error)
+    const errorMsg = error instanceof Error ? error.message : 'Failed to fetch synced users'
+    toast.error(errorMsg)
+  } finally {
+    setLoadingSyncedUsers(false)
+  }
+}

--- a/frontend/src/app/integrations/page.tsx
+++ b/frontend/src/app/integrations/page.tsx
@@ -98,187 +98,44 @@ import ManualSurveyDeliveryModal from "@/components/ManualSurveyDeliveryModal"
 import { SlackSurveyTabs } from "@/components/SlackSurveyTabs"
 import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
-import { z } from "zod"
-
-interface IntegrationMapping {
-  id: number | string // Can be number or "manual_123" for manual mappings
-  source_platform: string
-  source_identifier: string
-  source_name?: string  // User's full name from analysis data
-  target_platform: string
-  target_identifier: string | null
-  mapping_successful: boolean
-  mapping_method: string | null
-  error_message: string | null
-  data_collected: boolean
-  data_points_count: number | null
-  created_at: string
-  mapping_key: string
-  // New properties for manual mappings
-  is_manual?: boolean
-  source?: 'integration' | 'manual'
-  mapping_type?: string
-  status?: string
-  confidence_score?: number
-  last_verified?: string
-}
-
-interface MappingStatistics {
-  overall_success_rate: number
-  total_attempts: number
-  mapped_members?: number
-  members_with_data?: number
-  manual_mappings_count?: number
-  github_was_enabled?: boolean | null
-  platform_breakdown: {
-    [key: string]: {
-      total_attempts: number
-      successful: number
-      failed: number
-      success_rate: number
-    }
-  }
-}
-
-// New interface for analysis-specific mapping statistics
-interface AnalysisMappingStatistics {
-  total_team_members: number
-  successful_mappings: number
-  members_with_data: number
-  success_rate: number
-  failed_mappings: number
-}
-
-interface ManualMapping {
-  id: number
-  source_platform: string
-  source_identifier: string
-  target_platform: string
-  target_identifier: string
-  mapping_type: string
-  confidence_score?: number
-  last_verified?: string
-  created_at: string
-  updated_at?: string
-  status: string
-  is_verified: boolean
-  mapping_key: string
-}
-
-interface ManualMappingStatistics {
-  total_mappings: number
-  manual_mappings: number
-  auto_detected_mappings: number
-  verified_mappings: number
-  verification_rate: number
-  platform_breakdown: { [key: string]: { [key: string]: number } }
-  last_updated?: string
-}
-
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'
-
-// Validation schemas
-const rootlyFormSchema = z.object({
-  rootlyToken: z.string()
-    .min(1, "Rootly API token is required")
-    .regex(/^rootly_[a-f0-9]{64}$/, "Invalid Rootly token format. Token should start with 'rootly_' followed by 64 hex characters"),
-  nickname: z.string().optional(),
-})
-
-const pagerdutyFormSchema = z.object({
-  pagerdutyToken: z.string()
-    .min(1, "PagerDuty API token is required")
-    .regex(/^[A-Za-z0-9+_-]{20,32}$/, "Invalid PagerDuty token format. Token should be 20-32 characters long"),
-  nickname: z.string().optional(),
-})
-
-// Helper functions
-const isValidRootlyToken = (token: string): boolean => {
-  return /^rootly_[a-f0-9]{64}$/.test(token)
-}
-
-const isValidPagerDutyToken = (token: string): boolean => {
-  return /^[A-Za-z0-9+_-]{20,32}$/.test(token)
-}
-
-type RootlyFormData = z.infer<typeof rootlyFormSchema>
-type PagerDutyFormData = z.infer<typeof pagerdutyFormSchema>
-
-interface Integration {
-  id: number
-  name: string
-  organization_name: string
-  total_users: number
-  total_services?: number
-  is_default: boolean
-  created_at: string
-  last_used_at: string | null
-  token_suffix: string
-  platform: "rootly" | "pagerduty"
-  permissions?: {
-    users: {
-      access: boolean
-      error: string | null
-    }
-    incidents: {
-      access: boolean
-      error: string | null
-    }
-  }
-}
-
-interface GitHubIntegration {
-  id: number | string // Can be "beta-github" for beta integration
-  github_username: string
-  organizations: string[]
-  token_source: "oauth" | "manual" | "beta"
-  is_oauth: boolean
-  supports_refresh: boolean
-  connected_at: string
-  last_updated: string
-  is_beta?: boolean // Optional flag for beta integrations
-  token_preview?: string // Token preview for display
-}
-
-interface SlackIntegration {
-  id: number
-  slack_user_id: string | null
-  workspace_id: string
-  workspace_name?: string
-  token_source: "oauth" | "manual"
-  is_oauth: boolean
-  supports_refresh: boolean
-  has_webhook: boolean
-  webhook_configured: boolean
-  connected_at: string
-  last_updated: string
-  total_channels?: number
-  channel_names?: string[]
-  token_preview?: string
-  webhook_preview?: string
-  connection_type?: "oauth" | "manual"
-  status?: string
-  owner_user_id?: number
-}
-
-interface PreviewData {
-  organization_name: string
-  total_users: number
-  total_services?: number
-  suggested_name?: string
-  can_add?: boolean
-  current_user?: string
-  permissions?: {
-    users?: {
-      access: boolean
-      error?: string
-    }
-    incidents?: {
-      access: boolean
-      error?: string
-    }
-  }
-}
+import {
+  type Integration,
+  type GitHubIntegration,
+  type SlackIntegration,
+  type PreviewData,
+  type IntegrationMapping,
+  type MappingStatistics,
+  type AnalysisMappingStatistics,
+  type ManualMapping,
+  type ManualMappingStatistics,
+  type UserInfo,
+  type RootlyFormData,
+  type PagerDutyFormData,
+  rootlyFormSchema,
+  pagerdutyFormSchema,
+  isValidRootlyToken,
+  isValidPagerDutyToken,
+  API_BASE,
+} from "./types"
+import * as GithubHandlers from "./handlers/github-handlers"
+import * as SlackHandlers from "./handlers/slack-handlers"
+import * as TeamHandlers from "./handlers/team-handlers"
+import * as IntegrationHandlers from "./handlers/integration-handlers"
+import * as OrganizationHandlers from "./handlers/organization-handlers"
+import * as AIHandlers from "./handlers/ai-handlers"
+import * as MappingHandlers from "./handlers/mapping-handlers"
+import * as Utils from "./utils"
+import { GitHubIntegrationCard } from "./components/GitHubIntegrationCard"
+import { SlackIntegrationCard } from "./components/SlackIntegrationCard"
+import { GitHubConnectedCard } from "./components/GitHubConnectedCard"
+import { SlackConnectedCard } from "./components/SlackConnectedCard"
+import { RootlyIntegrationForm } from "./components/RootlyIntegrationForm"
+import { PagerDutyIntegrationForm } from "./components/PagerDutyIntegrationForm"
+import { DeleteIntegrationDialog } from "./dialogs/DeleteIntegrationDialog"
+import { GitHubDisconnectDialog } from "./dialogs/GitHubDisconnectDialog"
+import { SlackDisconnectDialog } from "./dialogs/SlackDisconnectDialog"
+import { NewMappingDialog } from "./dialogs/NewMappingDialog"
+import { OrganizationManagementDialog } from "./dialogs/OrganizationManagementDialog"
 
 export default function IntegrationsPage() {
   // State management
@@ -288,7 +145,7 @@ export default function IntegrationsPage() {
   const [loadingGitHub, setLoadingGitHub] = useState(true)
   const [loadingSlack, setLoadingSlack] = useState(true)
   const [reloadingIntegrations, setReloadingIntegrations] = useState(false)
-  const [userInfo, setUserInfo] = useState<{name: string, email: string, avatar?: string, organization_id?: number, id?: number, role?: string} | null>(null)
+  const [userInfo, setUserInfo] = useState<UserInfo | null>(null)
   const [activeTab, setActiveTab] = useState<"rootly" | "pagerduty" | null>(null)
   const [backUrl, setBackUrl] = useState<string>('/dashboard')
   const [selectedOrganization, setSelectedOrganization] = useState<string>("")
@@ -716,166 +573,19 @@ export default function IntegrationsPage() {
 
   // Load each provider independently for better UX
   const loadRootlyIntegrations = async (forceRefresh = false) => {
-    // Check cache first
-    if (!forceRefresh) {
-      const cachedIntegrations = localStorage.getItem('all_integrations')
-      if (cachedIntegrations) {
-        try {
-          const parsed = JSON.parse(cachedIntegrations)
-          const rootlyIntegrations = parsed.filter((i: Integration) => i.platform === 'rootly')
-          setIntegrations(prev => [
-            ...prev.filter(i => i.platform !== 'rootly'),
-            ...rootlyIntegrations
-          ])
-          setLoadingRootly(false)
-          return
-        } catch (e) {}
-      }
-    }
-
-    try {
-      const authToken = localStorage.getItem('auth_token')
-      if (!authToken) return
-
-      const response = await fetch(`${API_BASE}/rootly/integrations`, {
-        headers: { 'Authorization': `Bearer ${authToken}` }
-      })
-
-      const data = response.ok ? await response.json() : { integrations: [] }
-      const rootlyIntegrations = data.integrations.map((i: Integration) => ({ ...i, platform: 'rootly' }))
-
-      setIntegrations(prev => {
-        const updatedIntegrations = [
-          ...prev.filter(i => i.platform !== 'rootly'),
-          ...rootlyIntegrations
-        ]
-
-        // Update cache with fresh data when force refreshing
-        if (forceRefresh) {
-          localStorage.setItem('all_integrations', JSON.stringify(updatedIntegrations))
-          localStorage.setItem('all_integrations_timestamp', Date.now().toString())
-        }
-
-        return updatedIntegrations
-      })
-    } catch (error) {
-      console.error('Error loading Rootly integrations:', error)
-    } finally {
-      setLoadingRootly(false)
-    }
+    return IntegrationHandlers.loadRootlyIntegrations(forceRefresh, setIntegrations, setLoadingRootly)
   }
 
   const loadPagerDutyIntegrations = async (forceRefresh = false) => {
-    // Check cache first
-    if (!forceRefresh) {
-      const cachedIntegrations = localStorage.getItem('all_integrations')
-      if (cachedIntegrations) {
-        try {
-          const parsed = JSON.parse(cachedIntegrations)
-          const pagerdutyIntegrations = parsed.filter((i: Integration) => i.platform === 'pagerduty')
-          setIntegrations(prev => [
-            ...prev.filter(i => i.platform !== 'pagerduty'),
-            ...pagerdutyIntegrations
-          ])
-          setLoadingPagerDuty(false)
-          return
-        } catch (e) {}
-      }
-    }
-
-    try {
-      const authToken = localStorage.getItem('auth_token')
-      if (!authToken) return
-
-      const response = await fetch(`${API_BASE}/pagerduty/integrations`, {
-        headers: { 'Authorization': `Bearer ${authToken}` }
-      })
-
-      const data = response.ok ? await response.json() : { integrations: [] }
-      const pagerdutyIntegrations = data.integrations || []
-
-      setIntegrations(prev => {
-        const updatedIntegrations = [
-          ...prev.filter(i => i.platform !== 'pagerduty'),
-          ...pagerdutyIntegrations
-        ]
-
-        // Update cache with fresh data when force refreshing
-        if (forceRefresh) {
-          localStorage.setItem('all_integrations', JSON.stringify(updatedIntegrations))
-          localStorage.setItem('all_integrations_timestamp', Date.now().toString())
-        }
-
-        return updatedIntegrations
-      })
-    } catch (error) {
-      console.error('Error loading PagerDuty integrations:', error)
-    } finally {
-      setLoadingPagerDuty(false)
-    }
+    return IntegrationHandlers.loadPagerDutyIntegrations(forceRefresh, setIntegrations, setLoadingPagerDuty)
   }
 
   const loadGitHubIntegration = async (forceRefresh = false) => {
-    if (!forceRefresh) {
-      const cached = localStorage.getItem('github_integration')
-      if (cached) {
-        try {
-          const githubData = JSON.parse(cached)
-          setGithubIntegration(githubData.connected ? githubData.integration : null)
-          setLoadingGitHub(false)
-          return
-        } catch (e) {}
-      }
-    }
-
-    try {
-      const authToken = localStorage.getItem('auth_token')
-      if (!authToken) return
-
-      const response = await fetch(`${API_BASE}/integrations/github/status`, {
-        headers: { 'Authorization': `Bearer ${authToken}` }
-      })
-
-      const githubData = response.ok ? await response.json() : { connected: false, integration: null }
-      setGithubIntegration(githubData.connected ? githubData.integration : null)
-      localStorage.setItem('github_integration', JSON.stringify(githubData))
-    } catch (error) {
-      console.error('Error loading GitHub integration:', error)
-    } finally {
-      setLoadingGitHub(false)
-    }
+    return GithubHandlers.loadGitHubIntegration(forceRefresh, setGithubIntegration, setLoadingGitHub)
   }
 
   const loadSlackIntegration = async (forceRefresh = false) => {
-    if (!forceRefresh) {
-      const cached = localStorage.getItem('slack_integration')
-      if (cached) {
-        try {
-          const slackData = JSON.parse(cached)
-          setSlackIntegration(slackData.integration)
-          setLoadingSlack(false)
-          return
-        } catch (e) {}
-      }
-    }
-
-    try {
-      const authToken = localStorage.getItem('auth_token')
-      if (!authToken) return
-
-      const response = await fetch(`${API_BASE}/integrations/slack/status`, {
-        headers: { 'Authorization': `Bearer ${authToken}` }
-      })
-
-      const slackData = response.ok ? await response.json() : { integration: null }
-
-      setSlackIntegration(slackData.integration)
-      localStorage.setItem('slack_integration', JSON.stringify(slackData))
-    } catch (error) {
-      console.error('Error loading Slack integration:', error)
-    } finally {
-      setLoadingSlack(false)
-    }
+    return SlackHandlers.loadSlackIntegration(forceRefresh, setSlackIntegration, setLoadingSlack)
   }
 
   // ✨ PHASE 1 OPTIMIZATION: Instant cache loading with background refresh
@@ -925,140 +635,29 @@ export default function IntegrationsPage() {
 
   // Invite function
   const handleInvite = async () => {
-    if (!inviteEmail.trim()) {
-      toast.error("Please enter an email address")
-      return
-    }
-
-    setIsInviting(true)
-    try {
-      const authToken = localStorage.getItem('auth_token')
-      if (!authToken) {
-        toast.error("Authentication required")
-        return
-      }
-
-      const apiUrl = `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/invitations/create`
-
-      const response = await fetch(apiUrl, {
-        method: 'POST',
-        headers: {
-          'Authorization': `Bearer ${authToken}`,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          email: inviteEmail.trim(),
-          role: inviteRole
-        })
-      })
-
-      if (!response.ok) {
-        const responseText = await response.text()
-
-        // Try to parse as JSON, fallback to text
-        let errorMessage = 'Failed to send invitation'
-        try {
-          const errorData = JSON.parse(responseText)
-          errorMessage = errorData.detail || errorMessage
-        } catch {
-          errorMessage = responseText.includes('<!DOCTYPE')
-            ? 'API server not available or wrong URL'
-            : responseText
-        }
-
-        throw new Error(errorMessage)
-      }
-
-      const data = await response.json()
-      toast.success(`Invitation sent to ${inviteEmail}! They'll receive a notification and can accept within 30 days.`)
-
-      // Reset form and refresh organization data
-      setInviteEmail("")
-      setInviteRole("member")
-      setShowInviteModal(false)
-
-      // Refresh the organization data to show the new invitation
-      await loadOrganizationData()
-
-    } catch (error) {
-      console.error('Failed to send invitation:', error)
-      toast.error(error instanceof Error ? error.message : "Failed to send invitation")
-    } finally {
-      setIsInviting(false)
-    }
+    return OrganizationHandlers.handleInvite(
+      inviteEmail,
+      inviteRole,
+      setIsInviting,
+      setInviteEmail,
+      setInviteRole,
+      setShowInviteModal,
+      loadOrganizationData
+    )
   }
 
   // Handle role change for organization members
   const handleRoleChange = async (userId: number, newRole: string) => {
-    const authToken = localStorage.getItem('auth_token')
-    if (!authToken) {
-      toast.error("Authentication required")
-      return
-    }
-
-    try {
-      const response = await fetch(`${API_BASE}/api/auth/users/${userId}/role?new_role=${newRole}`, {
-        method: 'PATCH',
-        headers: {
-          'Authorization': `Bearer ${authToken}`,
-        }
-      })
-
-      if (response.ok) {
-        const data = await response.json()
-        toast.success(data.message || `Role updated successfully`)
-        // Reload organization data to reflect the change
-        await loadOrganizationData()
-      } else {
-        const errorData = await response.json()
-        throw new Error(errorData.detail || 'Failed to update role')
-      }
-    } catch (error) {
-      console.error('Failed to update role:', error)
-      toast.error(error instanceof Error ? error.message : 'Failed to update role')
-    }
+    return OrganizationHandlers.handleRoleChange(userId, newRole, loadOrganizationData)
   }
 
   // Load organization members and pending invitations
   const loadOrganizationData = async () => {
-    const authToken = localStorage.getItem('auth_token')
-    if (!authToken) return
-
-    setLoadingOrgData(true)
-    try {
-      // Load organization members
-      const membersResponse = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/api/invitations/organization/members`, {
-        headers: {
-          'Authorization': `Bearer ${authToken}`,
-        }
-      })
-
-      if (membersResponse.ok) {
-        const membersData = await membersResponse.json()
-        setOrgMembers(membersData.members || [])
-      } else {
-        const errorText = await membersResponse.text()
-      }
-
-      // Load pending invitations
-      const invitationsResponse = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/api/invitations/pending`, {
-        headers: {
-          'Authorization': `Bearer ${authToken}`,
-        }
-      })
-
-      if (invitationsResponse.ok) {
-        const invitationsData = await invitationsResponse.json()
-        setPendingInvitations(invitationsData.invitations || [])
-      } else {
-        const errorText = await invitationsResponse.text()
-      }
-
-    } catch (error) {
-      console.error('Failed to load organization data:', error)
-    } finally {
-      setLoadingOrgData(false)
-    }
+    return OrganizationHandlers.loadOrganizationData(
+      setLoadingOrgData,
+      setOrgMembers,
+      setPendingInvitations
+    )
   }
 
   // Background API loading - does NOT change loading states (for silent refresh)
@@ -1112,14 +711,7 @@ export default function IntegrationsPage() {
   }
   
   // Check if cache is stale (older than 5 minutes)
-  const isCacheStale = () => {
-    const cacheTimestamp = localStorage.getItem('all_integrations_timestamp')
-    if (!cacheTimestamp) return true
-    
-    const cacheAge = Date.now() - parseInt(cacheTimestamp)
-    const maxCacheAge = 5 * 60 * 1000 // 5 minutes
-    return cacheAge > maxCacheAge
-  }
+  const isCacheStale = Utils.isCacheStale
   
   // New optimized loading function with instant cache + background refresh
   const loadAllIntegrationsOptimized = async (forceRefresh = false) => {
@@ -1227,904 +819,197 @@ export default function IntegrationsPage() {
   }
 
   const loadLlmConfig = async () => {
-    setLoadingLlmConfig(true)
-    try {
-      const authToken = localStorage.getItem('auth_token')
-      if (!authToken) {
-        return
-      }
-
-      const response = await fetch(`${API_BASE}/llm/token`, {
-        headers: {
-          'Authorization': `Bearer ${authToken}`
-        }
-      })
-
-      if (response.ok) {
-        const config = await response.json()
-        setLlmConfig(config)
-        if (config.provider) {
-          setLlmProvider(config.provider)
-          setLlmModel(config.provider === 'openai' ? 'gpt-4o-mini' : 'claude-3-haiku')
-        }
-      }
-    } catch (error) {
-      console.error('Failed to load LLM config:', error)
-    } finally {
-      setLoadingLlmConfig(false)
-    }
+    return AIHandlers.loadLlmConfig(
+      setLoadingLlmConfig,
+      setLlmConfig,
+      setLlmProvider,
+      setLlmModel
+    )
   }
 
   const handleConnectAI = async () => {
-    if (!llmToken.trim()) {
-      setTokenError("Please enter your LLM API token")
-      toast.error("Please enter your LLM API token")
-      return
-    }
-
-    setIsConnectingAI(true)
-    setTokenError(null) // Clear any previous errors
-    try {
-      const authToken = localStorage.getItem('auth_token')
-      if (!authToken) {
-        throw new Error('No authentication token found')
-      }
-
-      const response = await fetch(`${API_BASE}/llm/token`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${authToken}`
-        },
-        body: JSON.stringify({
-          token: llmToken,
-          provider: llmProvider
-        })
-      })
-
-      if (response.ok) {
-        const result = await response.json()
-        setLlmConfig({
-          has_token: true,
-          provider: result.provider,
-          token_suffix: result.token_suffix
-        })
-        setLlmToken('')
-        setTokenError(null) // Clear any errors on success
-        toast.success(`Successfully connected ${result.provider} ${llmModel}`)
-      } else {
-        const error = await response.json()
-        const errorDetail = error.detail || 'Failed to connect AI'
-        
-        // Provide specific feedback based on error type
-        let title = "Connection Failed"
-        let description = errorDetail
-        
-        if (errorDetail.includes('format')) {
-          title = "Invalid Token Format"
-          description = `${llmProvider === 'openai' ? 'OpenAI' : 'Anthropic'} tokens must start with "${llmProvider === 'openai' ? 'sk-' : 'sk-ant-api'}"`
-        } else if (errorDetail.includes('verification failed') || errorDetail.includes('check your')) {
-          title = "Invalid API Token"
-          description = `The ${llmProvider === 'openai' ? 'OpenAI' : 'Anthropic'} token appears to be invalid or expired. Please verify your token and try again.`
-        } else if (errorDetail.includes('connect')) {
-          title = "Connection Error"
-          description = `Unable to connect to ${llmProvider === 'openai' ? 'OpenAI' : 'Anthropic'} API. Please check your internet connection and try again.`
-        }
-        
-        throw new Error(description)
-      }
-    } catch (error) {
-      console.error('Failed to connect AI:', error)
-      const errorMessage = error.message || "Failed to connect to AI service"
-      
-      // Determine toast title based on error content
-      let toastTitle = "Connection Failed"
-      if (errorMessage.includes('Invalid Token Format') || errorMessage.includes('must start with')) {
-        toastTitle = "Invalid Token Format"
-      } else if (errorMessage.includes('invalid or expired') || errorMessage.includes('verify your token')) {
-        toastTitle = "Invalid API Token"
-      } else if (errorMessage.includes('Connection Error') || errorMessage.includes('internet connection')) {
-        toastTitle = "Connection Error"
-      }
-      
-      // Set the error on the input field as well
-      setTokenError(errorMessage)
-      
-      toast.error(errorMessage)
-    } finally {
-      setIsConnectingAI(false)
-    }
+    return AIHandlers.handleConnectAI(
+      llmToken,
+      llmProvider,
+      llmModel,
+      setIsConnectingAI,
+      setTokenError,
+      setLlmConfig,
+      setLlmToken
+    )
   }
 
   const handleDisconnectAI = async () => {
-    try {
-      const authToken = localStorage.getItem('auth_token')
-      if (!authToken) {
-        throw new Error('No authentication token found')
-      }
-
-      const response = await fetch(`${API_BASE}/llm/token`, {
-        method: 'DELETE',
-        headers: {
-          'Authorization': `Bearer ${authToken}`
-        }
-      })
-
-      if (response.ok) {
-        setLlmConfig({has_token: false})
-        toast.success("LLM token removed successfully")
-      } else {
-        throw new Error('Failed to disconnect AI')
-      }
-    } catch (error) {
-      console.error('Failed to disconnect AI:', error)
-      toast.error("Failed to disconnect AI service")
-    }
+    return AIHandlers.handleDisconnectAI(setLlmConfig)
   }
 
   const testConnection = async (platform: "rootly" | "pagerduty", token: string) => {
-    setIsTestingConnection(true)
-    setConnectionStatus('idle')
-    setPreviewData(null)
-    setDuplicateInfo(null)
-    
-    try {
-      const authToken = localStorage.getItem('auth_token')
-      if (!authToken) {
-        throw new Error('No authentication token found')
-      }
-
-      const endpoint = platform === 'rootly' 
-        ? `${API_BASE}/rootly/token/test`
-        : `${API_BASE}/pagerduty/token/test`
-      
-
-      const response = await fetch(endpoint, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${authToken}`
-        },
-        body: JSON.stringify({
-          token: token
-        })
-      })
-
-      const data = await response.json()
-      
-
-      if (response.ok && (data.valid || data.status === 'success')) {
-        setConnectionStatus('success')
-        if (platform === 'rootly') {
-          setPreviewData({
-            organization_name: data.preview?.organization_name || data.account_info?.organization_name,
-            total_users: data.preview?.total_users || data.account_info?.total_users,
-            suggested_name: data.preview?.suggested_name || data.account_info?.suggested_name,
-            can_add: data.preview?.can_add || data.account_info?.can_add,
-            permissions: data.account_info?.permissions
-          })
-        } else {
-          setPreviewData(data.account_info)
-        }
-      } else if (response.status === 409) {
-        setConnectionStatus('duplicate')
-        setDuplicateInfo(data.detail)
-      } else {
-        setConnectionStatus('error')
-      }
-    } catch (error) {
-      console.error('Connection test error:', error)
-      setConnectionStatus('error')
-    } finally {
-      setIsTestingConnection(false)
-    }
+    return IntegrationHandlers.testConnection(
+      platform,
+      token,
+      setIsTestingConnection,
+      setConnectionStatus,
+      setPreviewData,
+      setDuplicateInfo
+    )
   }
 
   const addIntegration = async (platform: "rootly" | "pagerduty") => {
-    if (!previewData) return
-    
-    // Set service-specific loading state
-    if (platform === 'rootly') {
-      setIsAddingRootly(true)
-    } else {
-      setIsAddingPagerDuty(true)
-    }
-    try {
-      const authToken = localStorage.getItem('auth_token')
-      if (!authToken) {
-        throw new Error('No authentication token found')
-      }
-
-      const form = platform === 'rootly' ? rootlyForm : pagerdutyForm
-      const values = form.getValues()
-      const token = platform === 'rootly' ? (values as any).rootlyToken : (values as any).pagerdutyToken
-      const nickname = values.nickname
-
-      const endpoint = platform === 'rootly'
-        ? `${API_BASE}/rootly/token/add`
-        : `${API_BASE}/pagerduty/integrations`
-
-      const body = platform === 'rootly'
-        ? {
-            token: token,
-            name: nickname || previewData.suggested_name || previewData.organization_name,
-          }
-        : {
-            token: token,
-            name: nickname || previewData.organization_name,
-            platform: 'pagerduty'
-          }
-
-      const response = await fetch(endpoint, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${authToken}`
-        },
-        body: JSON.stringify(body)
-      })
-
-      const responseData = await response.json()
-
-      if (response.ok) {
-        toast.success(`Your ${platform === 'rootly' ? 'Rootly' : 'PagerDuty'} account has been connected successfully.`)
-
-        // Show loading toast for the reload process
-        const loadingToastId = toast.loading(`Adding ${platform === 'rootly' ? 'Rootly' : 'PagerDuty'} integration to your dashboard...`, {
-          duration: 0 // Persistent until dismissed
-        })
-
-        // Clear local storage cache
-        localStorage.removeItem(`${platform}_integrations`)
-        localStorage.removeItem(`${platform}_integrations_timestamp`)
-        localStorage.removeItem('all_integrations')
-        localStorage.removeItem('all_integrations_timestamp')
-
-        // If this is the first integration, set it as selected for dashboard
-        try {
-          const newIntegrationId = responseData.integration?.id || responseData.id
-          if (newIntegrationId && integrations.length === 0) {
-            localStorage.setItem('selected_organization', newIntegrationId.toString())
-          }
-        } catch (error) {
-          console.error('Error setting default integration:', error)
-          // Continue without setting default - not critical
-        }
-
-        // Reset form and state
-        form.reset()
-        setConnectionStatus('idle')
-        setPreviewData(null)
-        setAddingPlatform(null)
-
-        // Reload integrations to show the newly added one
-        setReloadingIntegrations(true)
-        try {
-          if (platform === 'rootly') {
-            await loadRootlyIntegrations(true)
-          } else {
-            await loadPagerDutyIntegrations(true)
-          }
-
-          // Dismiss loading toast and show success
-          toast.dismiss(loadingToastId)
-          toast.success(`${platform === 'rootly' ? 'Rootly' : 'PagerDuty'} integration added to dashboard!`)
-        } catch (reloadError) {
-          console.error('Error reloading integrations:', reloadError)
-          toast.dismiss(loadingToastId)
-          toast.error('Integration added but failed to refresh list. Please refresh the page.')
-        } finally {
-          setReloadingIntegrations(false)
-        }
-      } else {
-        throw new Error(responseData.detail?.message || responseData.message || 'Failed to add integration')
-      }
-    } catch (error) {
-      console.error('Add integration error:', error)
-      toast.error(error instanceof Error ? error.message : "An unexpected error occurred.")
-    } finally {
-      // Reset service-specific loading state
-      if (platform === 'rootly') {
-        setIsAddingRootly(false)
-      } else {
-        setIsAddingPagerDuty(false)
-      }
-    }
+    const form = platform === 'rootly' ? rootlyForm : pagerdutyForm
+    return IntegrationHandlers.addIntegration(
+      platform,
+      previewData,
+      form,
+      integrations,
+      setIsAddingRootly,
+      setIsAddingPagerDuty,
+      setConnectionStatus,
+      setPreviewData,
+      setAddingPlatform,
+      setReloadingIntegrations,
+      loadRootlyIntegrations,
+      loadPagerDutyIntegrations
+    )
   }
 
   const deleteIntegration = async () => {
     if (!integrationToDelete) return
-    
-    setIsDeleting(true)
-    try {
-      const authToken = localStorage.getItem('auth_token')
-      if (!authToken) return
-
-      const endpoint = integrationToDelete.platform === 'rootly'
-        ? `${API_BASE}/rootly/integrations/${integrationToDelete.id}`
-        : `${API_BASE}/pagerduty/integrations/${integrationToDelete.id}`
-
-      const response = await fetch(endpoint, {
-        method: 'DELETE',
-        headers: {
-          'Authorization': `Bearer ${authToken}`
-        }
-      })
-
-      if (response.ok) {
-        toast.success("The integration has been removed.")
-        
-        // Optimized: Update local state directly instead of full reload
-        const updatedIntegrations = integrations.filter(i => i.id !== integrationToDelete.id)
-        setIntegrations(updatedIntegrations)
-        
-        // Update cache with filtered results
-        localStorage.setItem('all_integrations', JSON.stringify(updatedIntegrations))
-        localStorage.setItem('all_integrations_timestamp', Date.now().toString())
-        
-        // Clear platform-specific cache
-        localStorage.removeItem(`${integrationToDelete.platform}_integrations`)
-        localStorage.removeItem(`${integrationToDelete.platform}_integrations_timestamp`)
-        
-        // If we deleted the currently selected integration, clear the selection
-        const selectedOrg = localStorage.getItem('selected_organization')
-        if (selectedOrg === integrationToDelete.id.toString()) {
-          localStorage.removeItem('selected_organization')
-        }
-        
-        setDeleteDialogOpen(false)
-        setIntegrationToDelete(null)
-      } else {
-        throw new Error('Failed to delete integration')
-      }
-    } catch (error) {
-      console.error('Delete error:', error)
-      toast.error("An error occurred while deleting the integration.")
-    } finally {
-      setIsDeleting(false)
-    }
+    return IntegrationHandlers.deleteIntegration(
+      integrationToDelete,
+      integrations,
+      setIsDeleting,
+      setIntegrations,
+      setDeleteDialogOpen,
+      setIntegrationToDelete
+    )
   }
 
   const updateIntegrationName = async (integration: Integration, newName: string) => {
-    setSavingIntegrationId(integration.id)
-    try {
-      const authToken = localStorage.getItem('auth_token')
-      if (!authToken) return
-
-      const endpoint = integration.platform === 'rootly'
-        ? `${API_BASE}/rootly/integrations/${integration.id}`
-        : `${API_BASE}/pagerduty/integrations/${integration.id}`
-
-      const response = await fetch(endpoint, {
-        method: 'PUT',
-        headers: {
-          'Authorization': `Bearer ${authToken}`,
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({ name: newName })
-      })
-
-      if (response.ok) {
-        toast.success("Integration name has been updated.")
-        
-        // Update the integration in state without reloading everything
-        setIntegrations(prevIntegrations => 
-          prevIntegrations.map(int => 
-            int.id === integration.id 
-              ? { ...int, name: newName }
-              : int
-          )
-        )
-        
-        // Clear cache to ensure next full reload has fresh data
-        localStorage.removeItem('all_integrations')
-        localStorage.removeItem('all_integrations_timestamp')
-      }
-    } catch (error) {
-      console.error('Error updating name:', error)
-      toast.error("Could not update integration name.")
-    } finally {
-      setSavingIntegrationId(null)
-    }
+    return IntegrationHandlers.updateIntegrationName(
+      integration,
+      newName,
+      setSavingIntegrationId,
+      setIntegrations,
+      setEditingIntegration
+    )
   }
 
 
   const copyToClipboard = async (text: string) => {
-    try {
-      await navigator.clipboard.writeText(text)
-      setCopied(true)
-      setTimeout(() => setCopied(false), 2000)
-    } catch (err) {
-      console.error('Failed to copy: ', err)
-    }
+    return Utils.copyToClipboard(text, setCopied)
   }
 
   // GitHub integration handlers
   const handleGitHubConnect = async (token: string) => {
-    setIsConnectingGithub(true)
-    try {
-      const authToken = localStorage.getItem('auth_token')
-      if (!authToken) {
-        throw new Error('No authentication token found')
-      }
-
-      const response = await fetch(`${API_BASE}/integrations/github/token`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${authToken}`
-        },
-        body: JSON.stringify({ token })
-      })
-
-      if (!response.ok) {
-        const errorData = await response.json()
-        throw new Error(errorData.detail || 'Failed to connect GitHub')
-      }
-
-      toast.success("Your GitHub account has been connected successfully.")
-      
-      setGithubToken('')
-      setActiveEnhancementTab(null)
-      loadGitHubIntegration(true) // Force refresh to update cache
-    } catch (error) {
-      console.error('Error connecting GitHub:', error)
-      toast.error(error instanceof Error ? error.message : "An unexpected error occurred.")
-    } finally {
-      setIsConnectingGithub(false)
-    }
+    return GithubHandlers.handleGitHubConnect(
+      token,
+      setIsConnectingGithub,
+      setGithubToken,
+      setActiveEnhancementTab,
+      loadGitHubIntegration
+    )
   }
 
   const handleGitHubDisconnect = async () => {
-    setIsDisconnectingGithub(true)
-    try {
-      const authToken = localStorage.getItem('auth_token')
-      if (!authToken) return
-
-      const response = await fetch(`${API_BASE}/integrations/github/disconnect`, {
-        method: 'DELETE',
-        headers: {
-          'Authorization': `Bearer ${authToken}`
-        }
-      })
-
-      if (response.ok) {
-        toast.success("Your GitHub integration has been removed.")
-        setGithubDisconnectDialogOpen(false)
-        loadGitHubIntegration(true) // Force refresh after changes
-      }
-    } catch (error) {
-      console.error('Error disconnecting GitHub:', error)
-      toast.error(error instanceof Error ? error.message : "An unexpected error occurred.")
-    } finally {
-      setIsDisconnectingGithub(false)
-    }
+    return GithubHandlers.handleGitHubDisconnect(
+      setIsDisconnectingGithub,
+      setGithubDisconnectDialogOpen,
+      loadGitHubIntegration
+    )
   }
 
   const handleGitHubTest = async () => {
-    try {
-      const authToken = localStorage.getItem('auth_token')
-      if (!authToken) {
-        toast.error("Please log in to test your GitHub integration.")
-        return
-      }
-
-      toast.info("Testing GitHub connection...")
-
-      const response = await fetch(`${API_BASE}/integrations/github/test`, {
-        method: 'POST',
-        headers: {
-          'Authorization': `Bearer ${authToken}`
-        }
-      })
-
-      if (response.ok) {
-        const data = await response.json()
-        // Show permissions info if available
-        if (data.permissions) {
-          const missingPerms = []
-          if (!data.permissions.repo_access) missingPerms.push('repository access')
-          if (!data.permissions.org_access) missingPerms.push('organization access')
-          
-          if (missingPerms.length > 0) {
-            toast.warning(`✅ Connected as ${data.user_info?.username || 'GitHub user'}, but missing: ${missingPerms.join(', ')}`)
-          } else {
-            toast.success(`✅ GitHub test successful! Connected as ${data.user_info?.username || 'GitHub user'} with full access.`)
-          }
-        } else {
-          toast.success(`✅ GitHub test successful! Connected as ${data.user_info?.username || 'GitHub user'}. Integration is working properly.`)
-        }
-      } else {
-        const errorData = await response.json().catch(() => ({}))
-        throw new Error(errorData.detail || 'Connection test failed')
-      }
-    } catch (error) {
-      console.error('Error testing GitHub connection:', error)
-      toast.error(`❌ GitHub test failed: ${error instanceof Error ? error.message : "Unable to test GitHub connection."}`)
-    }
+    return GithubHandlers.handleGitHubTest()
   }
 
   // Slack integration handlers
   const handleSlackConnect = async (webhookUrl: string, botToken: string) => {
-    setIsConnectingSlack(true)
-    try {
-      const authToken = localStorage.getItem('auth_token')
-      if (!authToken) {
-        throw new Error('No authentication token found')
-      }
-
-      const response = await fetch(`${API_BASE}/integrations/slack/setup`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${authToken}`
-        },
-        body: JSON.stringify({ 
-          webhook_url: webhookUrl,
-          token: botToken 
-        })
-      })
-
-      if (!response.ok) {
-        const errorData = await response.json()
-        throw new Error(errorData.detail || 'Failed to connect Slack')
-      }
-
-      toast.success("Your Slack workspace has been connected successfully.")
-      
-      setSlackWebhookUrl('')
-      setSlackBotToken('')
-      setActiveEnhancementTab(null)
-      loadSlackIntegration(true)
-    } catch (error) {
-      console.error('Error connecting Slack:', error)
-      toast.error(error instanceof Error ? error.message : "An unexpected error occurred.")
-    } finally {
-      setIsConnectingSlack(false)
-    }
+    return SlackHandlers.handleSlackConnect(
+      webhookUrl,
+      botToken,
+      setIsConnectingSlack,
+      setSlackWebhookUrl,
+      setSlackBotToken,
+      setActiveEnhancementTab,
+      loadSlackIntegration
+    )
   }
 
   const handleSlackDisconnect = async () => {
-    setIsDisconnectingSlack(true)
-    try {
-      const authToken = localStorage.getItem('auth_token')
-      if (!authToken) return
-
-      const response = await fetch(`${API_BASE}/integrations/slack/disconnect`, {
-        method: 'DELETE',
-        headers: {
-          'Authorization': `Bearer ${authToken}`
-        }
-      })
-
-      if (response.ok) {
-        toast.success("Your Slack integration has been removed.")
-        setSlackDisconnectDialogOpen(false)
-        loadSlackIntegration(true) // Force refresh after changes
-      }
-    } catch (error) {
-      console.error('Error disconnecting Slack:', error)
-      toast.error(error instanceof Error ? error.message : "An unexpected error occurred.")
-    } finally {
-      setIsDisconnectingSlack(false)
-    }
+    return SlackHandlers.handleSlackDisconnect(
+      setIsDisconnectingSlack,
+      setSlackDisconnectDialogOpen,
+      loadSlackIntegration
+    )
   }
 
   const handleSlackTest = async () => {
-    try {
-      const authToken = localStorage.getItem('auth_token')
-      if (!authToken) {
-        toast.error("Please log in to test your Slack integration.")
-        return
-      }
-
-      toast.info("Testing Slack connection...")
-
-      const response = await fetch(`${API_BASE}/integrations/slack/test`, {
-        method: 'POST',
-        headers: {
-          'Authorization': `Bearer ${authToken}`
-        }
-      })
-
-      if (response.ok) {
-        const data = await response.json()
-        setSlackPermissions(data.permissions)
-        
-        // Store channels list if available
-        if (data.channels) {
-          setSlackIntegration(prev => prev ? {...prev, channels: data.channels} : null)
-        }
-        
-        const workspaceName = data.workspace_info?.team_name || 'your workspace'
-        const userName = data.user_info?.name || 'Slack user'
-        
-        toast.success(`✅ Slack test successful! Connected as ${userName} in ${workspaceName}. Permissions updated.`)
-      } else {
-        const errorData = await response.json().catch(() => ({}))
-        throw new Error(errorData.detail || 'Connection test failed')
-      }
-    } catch (error) {
-      console.error('Error testing Slack connection:', error)
-      toast.error(`❌ Slack test failed: ${error instanceof Error ? error.message : "Unable to test Slack connection."}`)
-    }
+    return SlackHandlers.handleSlackTest(setSlackPermissions, setSlackIntegration)
   }
 
   const loadSlackPermissions = async () => {
-    if (!slackIntegration) return
-    
-    setIsLoadingPermissions(true)
-    try {
-      const authToken = localStorage.getItem('auth_token')
-      if (!authToken) return
-
-      const response = await fetch(`${API_BASE}/integrations/slack/test`, {
-        method: 'POST',
-        headers: {
-          'Authorization': `Bearer ${authToken}`
-        }
-      })
-
-      if (response.ok) {
-        const data = await response.json()
-        setSlackPermissions(data.permissions)
-      }
-    } catch (error) {
-      console.error('Error loading Slack permissions:', error)
-    } finally {
-      setIsLoadingPermissions(false)
-    }
+    return SlackHandlers.loadSlackPermissions(slackIntegration, setIsLoadingPermissions, setSlackPermissions)
   }
 
   // Mapping data handlers
   // Function to open the reusable MappingDrawer
   const openMappingDrawer = (platform: 'github' | 'slack') => {
-    setMappingDrawerPlatform(platform)
-    setMappingDrawerOpen(true)
+    return Utils.openMappingDrawer(platform, setMappingDrawerPlatform, setMappingDrawerOpen)
   }
 
   const loadMappingData = async (platform: 'github' | 'slack') => {
-    setLoadingMappingData(true)
-    setSelectedMappingPlatform(platform)
-    
-    try {
-      const authToken = localStorage.getItem('auth_token')
-      if (!authToken) {
-        toast.error('Please log in to view mapping data')
-        return
-      }
-
-      // Use the existing working endpoints
-      
-      const [mappingsResponse, statsResponse] = await Promise.all([
-        fetch(`${API_BASE}/integrations/mappings/platform/${platform}`, {
-          headers: { 'Authorization': `Bearer ${authToken}` }
-        }),
-        fetch(`${API_BASE}/integrations/mappings/success-rate?platform=${platform}`, {
-          headers: { 'Authorization': `Bearer ${authToken}` }
-        })
-      ])
-
-
-      if (mappingsResponse.ok && statsResponse.ok) {
-        const mappings = await mappingsResponse.json()
-        const stats = await statsResponse.json()
-        
-        const failedMappings = mappings.filter(m => !m.target_identifier)
-        const successfulMappings = mappings.filter(m => m.target_identifier)
-        
-        
-        setMappingData(mappings)
-        setMappingStats(stats)
-        setAnalysisMappingStats(null)
-        setCurrentAnalysisId(null)
-        setShowMappingDialog(true)
-        
-        
-        // Show success message only if dialog is already open (refresh action)
-        if (showMappingDialog) {
-          toast.success(`${platform === 'github' ? 'GitHub' : 'Slack'} mapping data refreshed successfully`)
-        }
-      } else {
-        throw new Error(`Failed to fetch mapping data - Mappings: ${mappingsResponse.status}, Stats: ${statsResponse.status}`)
-      }
-    } catch (error) {
-      toast.error(`Failed to load mapping data: ${error.message}`)
-    } finally {
-      setLoadingMappingData(false)
-    }
+    return MappingHandlers.loadMappingData(
+      platform,
+      showMappingDialog,
+      setLoadingMappingData,
+      setSelectedMappingPlatform,
+      setMappingData,
+      setMappingStats,
+      setAnalysisMappingStats,
+      setCurrentAnalysisId,
+      setShowMappingDialog
+    )
   }
 
   // Fetch team members from selected organization
   const fetchTeamMembers = async () => {
-    if (!selectedOrganization) {
-      toast.error('Please select an organization first')
-      return
-    }
-    setLoadingTeamMembers(true)
-    setTeamMembersError(null)
-
-    try {
-      const authToken = localStorage.getItem('auth_token')
-      if (!authToken) {
-        toast.error('Please log in to view team members')
-        return
-      }
-
-      const response = await fetch(`${API_BASE}/rootly/integrations/${selectedOrganization}/users`, {
-        headers: {
-          'Authorization': `Bearer ${authToken}`,
-          'Content-Type': 'application/json'
-        }
-      })
-
-      if (response.ok) {
-        const data = await response.json()
-        setTeamMembers(data.users || [])
-        setTeamMembersDrawerOpen(true)
-        toast.success(`Loaded ${data.total_users} team members from ${data.integration_name}`)
-      } else {
-        const errorData = await response.json()
-        throw new Error(errorData.detail || 'Failed to fetch team members')
-      }
-    } catch (error) {
-      console.error('Error fetching team members:', error)
-      const errorMsg = error instanceof Error ? error.message : 'Failed to fetch team members'
-      setTeamMembersError(errorMsg)
-      toast.error(errorMsg)
-    } finally {
-      setLoadingTeamMembers(false)
-    }
+    return TeamHandlers.fetchTeamMembers(
+      selectedOrganization,
+      setLoadingTeamMembers,
+      setTeamMembersError,
+      setTeamMembers,
+      setTeamMembersDrawerOpen
+    )
   }
 
   // Sync users to UserCorrelation table
   const syncUsersToCorrelation = async () => {
-    if (!selectedOrganization) {
-      toast.error('Please select an organization first')
-      return
-    }
-    setLoadingTeamMembers(true)
-    setTeamMembersError(null)
-
-    try {
-      const authToken = localStorage.getItem('auth_token')
-      if (!authToken) {
-        toast.error('Please log in to sync users')
-        return
-      }
-
-      const response = await fetch(`${API_BASE}/rootly/integrations/${selectedOrganization}/sync-users`, {
-        method: 'POST',
-        headers: {
-          'Authorization': `Bearer ${authToken}`,
-          'Content-Type': 'application/json'
-        }
-      })
-
-      if (response.ok) {
-        const data = await response.json()
-        const stats = data.stats || data
-        toast.success(
-          `Synced ${stats.created} new users, updated ${stats.updated} existing users. ` +
-          `All team members can now submit burnout surveys via Slack!`
-        )
-        // Reload the members list and fetch synced users (without showing another toast or auto-syncing again)
-        await fetchTeamMembers()
-        await fetchSyncedUsers(false, false)
-      } else {
-        const errorData = await response.json()
-        throw new Error(errorData.detail || 'Failed to sync users')
-      }
-    } catch (error) {
-      console.error('Error syncing users:', error)
-      const errorMsg = error instanceof Error ? error.message : 'Failed to sync users'
-      setTeamMembersError(errorMsg)
-      toast.error(errorMsg)
-    } finally {
-      setLoadingTeamMembers(false)
-    }
+    return TeamHandlers.syncUsersToCorrelation(
+      selectedOrganization,
+      setLoadingTeamMembers,
+      setTeamMembersError,
+      fetchTeamMembers,
+      fetchSyncedUsers
+    )
   }
 
   // Sync Slack user IDs to UserCorrelation records
   const syncSlackUserIds = async () => {
-    setLoadingTeamMembers(true)
-
-    try {
-      const authToken = localStorage.getItem('auth_token')
-      if (!authToken) {
-        toast.error('Please log in to sync Slack user IDs')
-        return
-      }
-
-      const response = await fetch(`${API_BASE}/integrations/slack/sync-user-ids`, {
-        method: 'POST',
-        headers: {
-          'Authorization': `Bearer ${authToken}`,
-          'Content-Type': 'application/json'
-        }
-      })
-
-      if (response.ok) {
-        const data = await response.json()
-        const stats = data.stats || {}
-        toast.success(
-          `Synced Slack IDs for ${stats.updated} users! ` +
-          `${stats.skipped} users skipped (no matching Slack account).`
-        )
-        // Refresh synced users list
-        await fetchSyncedUsers(false)
-      } else {
-        const errorData = await response.json()
-        throw new Error(errorData.detail || 'Failed to sync Slack user IDs')
-      }
-    } catch (error) {
-      console.error('Error syncing Slack user IDs:', error)
-      const errorMsg = error instanceof Error ? error.message : 'Failed to sync Slack user IDs'
-      toast.error(errorMsg)
-    } finally {
-      setLoadingTeamMembers(false)
-    }
+    return TeamHandlers.syncSlackUserIds(setLoadingTeamMembers, fetchSyncedUsers)
   }
 
   // Fetch synced users from database
   const fetchSyncedUsers = async (showToast = true, autoSync = true) => {
-
-    if (!selectedOrganization) {
-      toast.error('Please select an organization first')
-      return
-    }
-
-    setLoadingSyncedUsers(true)
-
-    try {
-      const authToken = localStorage.getItem('auth_token')
-      if (!authToken) {
-        toast.error('Please log in to view synced users')
-        return
-      }
-
-      const response = await fetch(`${API_BASE}/rootly/synced-users?integration_id=${selectedOrganization}`, {
-        headers: {
-          'Authorization': `Bearer ${authToken}`,
-          'Content-Type': 'application/json'
-        }
-      })
-
-      if (response.ok) {
-        const data = await response.json()
-        const users = data.users || []
-        setSyncedUsers(users)
-        setShowSyncedUsers(true)
-        setTeamMembersDrawerOpen(true)
-
-        // If no users found, automatically sync them (but not for beta integrations)
-        // Only auto-sync once to prevent infinite loops
-        if (users.length === 0 && !selectedOrganization.startsWith('beta-') && autoSync) {
-          toast.info('No synced users found. Syncing now...')
-          setLoadingSyncedUsers(false) // Reset loading state before syncing
-          await syncUsersToCorrelation()
-          // syncUsersToCorrelation will call fetchSyncedUsers again after syncing
-          return
-        }
-
-        if (showToast) {
-          if (users.length === 0) {
-            toast.info('Beta integrations show users from shared access. Use "Sync Members" with your own integration to enable survey submissions.')
-          } else {
-            toast.success(`Found ${data.total} synced users`)
-          }
-        }
-      } else {
-        const errorData = await response.json()
-        throw new Error(errorData.detail || 'Failed to fetch synced users')
-      }
-    } catch (error) {
-      console.error('Error fetching synced users:', error)
-      const errorMsg = error instanceof Error ? error.message : 'Failed to fetch synced users'
-      toast.error(errorMsg)
-    } finally {
-      setLoadingSyncedUsers(false)
-    }
+    return TeamHandlers.fetchSyncedUsers(
+      selectedOrganization,
+      setLoadingSyncedUsers,
+      setSyncedUsers,
+      setShowSyncedUsers,
+      setTeamMembersDrawerOpen,
+      syncUsersToCorrelation,
+      showToast,
+      autoSync
+    )
   }
 
   // Inline mapping edit handlers
@@ -2141,83 +1026,21 @@ export default function IntegrationsPage() {
   
   // Validate GitHub username
   const validateGithubUsername = async (username: string) => {
-    if (!username.trim()) {
-      setGithubValidation({ valid: false, message: 'Username cannot be empty' })
-      return false
-    }
-    
-    setValidatingGithub(true)
-    try {
-      const authToken = localStorage.getItem('auth_token')
-      if (!authToken) {
-        setGithubValidation({ valid: false, message: 'Not authenticated' })
-        return false
-      }
-      
-      const response = await fetch(`${API_BASE}/integrations/mappings/github/validate/${encodeURIComponent(username.trim())}`, {
-        headers: { 'Authorization': `Bearer ${authToken}` }
-      })
-      
-      const data = await response.json()
-      
-      if (response.ok && data.valid) {
-        setGithubValidation({ valid: true, message: `Found: ${data.name || data.username}` })
-        return true
-      } else {
-        const errorMsg = data.message || data.error || `API Error (${response.status})`
-        setGithubValidation({ valid: false, message: errorMsg })
-        return false
-      }
-    } catch (error) {
-      console.error('Error validating GitHub username:', error)
-      setGithubValidation({ valid: false, message: 'Validation failed' })
-      return false
-    } finally {
-      setValidatingGithub(false)
-    }
+    return MappingHandlers.validateGithubUsername(
+      username,
+      setValidatingGithub,
+      setGithubValidation
+    )
   }
   
   // Sorting function
   const handleSort = (field: 'email' | 'status' | 'data' | 'method') => {
-    if (sortField === field) {
-      setSortDirection(sortDirection === 'asc' ? 'desc' : 'asc')
-    } else {
-      setSortField(field)
-      setSortDirection('asc')
-    }
+    return Utils.handleSort(field, sortField, sortDirection, setSortField, setSortDirection)
   }
-  
+
   // Filter and sort mappings
-  const filteredMappings = showOnlyFailed 
-    ? mappingData.filter(m => !m.mapping_successful)
-    : mappingData
-    
-  const sortedMappings = [...filteredMappings].sort((a, b) => {
-    let aValue: any, bValue: any
-    
-    switch (sortField) {
-      case 'email':
-        aValue = a.source_identifier.toLowerCase()
-        bValue = b.source_identifier.toLowerCase()
-        break
-      case 'status':
-        aValue = a.mapping_successful ? 1 : 0
-        bValue = b.mapping_successful ? 1 : 0
-        break
-      case 'data':
-        aValue = a.data_points_count || 0
-        bValue = b.data_points_count || 0
-        break
-      case 'method':
-        aValue = a.mapping_method || ''
-        bValue = b.mapping_method || ''
-        break
-    }
-    
-    if (aValue < bValue) return sortDirection === 'asc' ? -1 : 1
-    if (aValue > bValue) return sortDirection === 'asc' ? 1 : -1
-    return 0
-  })
+  const filteredMappings = Utils.filterMappings(mappingData, showOnlyFailed)
+  const sortedMappings = Utils.sortMappings(filteredMappings, sortField, sortDirection)
 
   const cancelInlineEdit = () => {
     setInlineEditingId(null)
@@ -2232,127 +1055,19 @@ export default function IntegrationsPage() {
   }
 
   const saveEditedMapping = async (mappingId: number | string, email: string) => {
-    if (!inlineEditingValue.trim()) {
-      toast.error('Please enter a valid username')
-      return
-    }
-    
-    const authToken = localStorage.getItem('auth_token')
-    if (!authToken) {
-      toast.error('Please log in to edit mappings')
-      return
-    }
-    
-    // Validate GitHub username first (for both manual and auto mappings)
-    if (selectedMappingPlatform === 'github') {
-      if (!githubValidation || githubValidation.valid !== true) {
-        const isValid = await validateGithubUsername(inlineEditingValue)
-        if (!isValid) {
-          toast.error(`Invalid GitHub username: ${githubValidation?.message || 'User not found'}`, {
-            duration: 4000
-          })
-          return
-        }
-      }
-    }
-    
-    // Handle manual mappings differently (use UserMapping endpoint during migration period)
-    if (typeof mappingId === 'string' && mappingId.startsWith('manual_')) {
-      // Extract the numeric ID from "manual_123" format
-      const numericId = parseInt(mappingId.replace('manual_', ''))
-      
-      setSavingInlineMapping(true)
-      try {
-        // Use the manual mappings endpoint instead
-        const response = await fetch(`${API_BASE}/integrations/manual-mappings/${numericId}`, {
-          method: 'PUT',
-          headers: {
-            'Authorization': `Bearer ${authToken}`,
-            'Content-Type': 'application/json'
-          },
-          body: JSON.stringify({
-            target_identifier: inlineEditingValue.trim()
-          })
-        })
-
-        if (response.ok) {
-          const result = await response.json()
-          toast.success(`Successfully updated manual mapping to '${inlineEditingValue}'`)
-          
-          // Update the local mapping data
-          setMappingData(prevData => 
-            prevData.map(m => 
-              m.id === mappingId 
-                ? { ...m, target_identifier: inlineEditingValue.trim(), mapping_successful: true }
-                : m
-            )
-          )
-          
-          // Clear editing state
-          setInlineEditingId(null)
-          setInlineEditingValue('')
-          setGithubValidation(null)
-          return
-        } else {
-          const errorData = await response.json()
-          toast.error(errorData.detail || 'Failed to update manual mapping')
-          return
-        }
-      } catch (error) {
-        console.error('Manual mapping edit error:', error)
-        toast.error('Failed to update manual mapping')
-        return
-      } finally {
-        setSavingInlineMapping(false)
-      }
-    }
-
-    setSavingInlineMapping(true)
-    try {
-
-      const response = await fetch(`${API_BASE}/integrations/mappings/${mappingId}/edit?new_target_identifier=${encodeURIComponent(inlineEditingValue.trim())}`, {
-        method: 'PUT',
-        headers: {
-          'Authorization': `Bearer ${authToken}`,
-          'Content-Type': 'application/json'
-        }
-      })
-
-      if (response.ok) {
-        const result = await response.json()
-        toast.success(result.message || `Successfully updated mapping to '${inlineEditingValue}'`)
-        
-        // Update the local mapping data
-        setMappingData(prevData => 
-          prevData.map(m => 
-            m.id === mappingId 
-              ? { 
-                  ...m, 
-                  target_identifier: inlineEditingValue.trim(),
-                  mapping_successful: true,
-                  is_manual: true,  // It becomes manual after editing
-                  source: 'manual',
-                  mapping_method: 'manual_edit',
-                  last_updated: new Date().toISOString()
-                } 
-              : m
-          )
-        )
-        
-        // Clear editing state
-        setInlineEditingId(null)
-        setInlineEditingValue('')
-        setGithubValidation(null)
-      } else {
-        const errorData = await response.json()
-        toast.error(errorData.message || 'Failed to update mapping')
-      }
-    } catch (error) {
-      console.error('Error updating mapping:', error)
-      toast.error('Failed to update mapping')
-    } finally {
-      setSavingInlineMapping(false)
-    }
+    return MappingHandlers.saveEditedMapping(
+      mappingId,
+      email,
+      inlineEditingValue,
+      selectedMappingPlatform,
+      githubValidation,
+      setSavingInlineMapping,
+      setMappingData,
+      setInlineEditingId,
+      setInlineEditingValue,
+      setGithubValidation,
+      validateGithubUsername
+    )
   }
   
   // Handle inline value change with debounced validation
@@ -2371,240 +1086,61 @@ export default function IntegrationsPage() {
   }
 
   const saveInlineMapping = async (mappingId: number | string, email: string) => {
-    // Skip manual mappings - they can't be edited inline as they already exist
-    if (typeof mappingId === 'string' && mappingId.startsWith('manual_')) {
-      toast.error('Manual mappings cannot be edited inline')
-      return
-    }
-    if (!inlineEditingValue.trim()) {
-      toast.error('Please enter a GitHub username')
-      return
-    }
-    
-    // Validate GitHub username first
-    if (selectedMappingPlatform === 'github') {
-      // If we haven't validated yet or validation failed, validate now
-      if (!githubValidation || githubValidation.valid !== true) {
-        const isValid = await validateGithubUsername(inlineEditingValue)
-        if (!isValid) {
-          toast.error(`Invalid GitHub username: ${githubValidation?.message || 'User not found'}`, {
-            duration: 4000
-          })
-          return
-        }
-      }
-    }
-
-    setSavingInlineMapping(true)
-    try {
-      const authToken = localStorage.getItem('auth_token')
-      if (!authToken) {
-        toast.error('Please log in to save mappings')
-        return
-      }
-
-      const response = await fetch(`${API_BASE}/integrations/manual-mappings`, {
-        method: 'POST',
-        headers: {
-          'Authorization': `Bearer ${authToken}`,
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({
-          source_platform: 'rootly',
-          source_identifier: email,
-          target_platform: selectedMappingPlatform,
-          target_identifier: inlineEditingValue.trim()
-        })
-      })
-
-      if (response.ok) {
-        toast.success(`Manual mapping saved: ${email} → ${inlineEditingValue}`)
-        
-        // Update the local mapping data to show the change immediately
-        setMappingData(prevData => 
-          prevData.map(m => 
-            m.id === mappingId 
-              ? { 
-                  ...m, 
-                  target_identifier: inlineEditingValue.trim(),
-                  mapping_successful: true,
-                  error_message: null,
-                  mapping_method: 'manual'
-                }
-              : m
-          )
-        )
-        
-        // Reset inline editing state
-        setInlineEditingId(null)
-        setInlineEditingValue('')
-        
-        // Note: The manual mapping is saved but won't show in IntegrationMapping 
-        // until the next analysis is run
-        toast.info('Manual mapping saved. Run a new analysis to use this mapping.', {
-          duration: 5000
-        })
-      } else {
-        const error = await response.json()
-        toast.error(`Failed to save mapping: ${error.detail || 'Unknown error'}`)
-      }
-    } catch (error) {
-      console.error('Error saving manual mapping:', error)
-      toast.error('Failed to save mapping')
-    } finally {
-      setSavingInlineMapping(false)
-    }
+    return MappingHandlers.saveInlineMapping(
+      mappingId,
+      email,
+      inlineEditingValue,
+      selectedMappingPlatform,
+      githubValidation,
+      setSavingInlineMapping,
+      setMappingData,
+      setInlineEditingId,
+      setInlineEditingValue,
+      validateGithubUsername
+    )
   }
 
   // Manual mapping handlers
   const loadManualMappings = async (platform: 'github' | 'slack') => {
-    try {
-      setLoadingManualMappings(true)
-      setSelectedManualMappingPlatform(platform)
-      
-      const authToken = localStorage.getItem('auth_token')
-      if (!authToken) {
-        toast.error('Please log in to view manual mappings')
-        return
-      }
-      
-      const [mappingsResponse, statsResponse] = await Promise.all([
-        fetch(`${API_BASE}/integrations/manual-mappings?target_platform=${platform}`, {
-          headers: {
-            'Authorization': `Bearer ${authToken}`,
-            'Content-Type': 'application/json'
-          }
-        }),
-        fetch(`${API_BASE}/integrations/manual-mappings/statistics`, {
-          headers: {
-            'Authorization': `Bearer ${authToken}`,
-            'Content-Type': 'application/json'
-          }
-        })
-      ])
-      
-      if (mappingsResponse.ok && statsResponse.ok) {
-        const mappingsData = await mappingsResponse.json()
-        const statsData = await statsResponse.json()
-        
-        setManualMappings(mappingsData)
-        setManualMappingStats(statsData)
-        setShowManualMappingDialog(true)
-      } else {
-        toast.error('Failed to load manual mappings')
-      }
-    } catch (error) {
-      console.error('Error loading manual mappings:', error)
-      toast.error('Failed to load manual mappings')
-    } finally {
-      setLoadingManualMappings(false)
-    }
+    return MappingHandlers.loadManualMappings(
+      platform,
+      setLoadingManualMappings,
+      setSelectedManualMappingPlatform,
+      setManualMappings,
+      setManualMappingStats,
+      setShowManualMappingDialog
+    )
   }
 
   const createManualMapping = async () => {
-    try {
-      const authToken = localStorage.getItem('auth_token')
-      if (!authToken) {
-        toast.error('Please log in to create mappings')
-        return
-      }
-
-      const response = await fetch(`${API_BASE}/integrations/manual-mappings`, {
-        method: 'POST',
-        headers: {
-          'Authorization': `Bearer ${authToken}`,
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify(newMappingForm)
-      })
-      
-      if (response.ok) {
-        toast.success('Manual mapping created successfully')
-        // Reload mappings if dialog is open
-        if (showManualMappingDialog && selectedManualMappingPlatform) {
-          loadManualMappings(selectedManualMappingPlatform)
-        }
-        setNewMappingDialogOpen(false)
-        setNewMappingForm({
-          source_platform: 'rootly',
-          source_identifier: '',
-          target_platform: selectedManualMappingPlatform || 'github',
-          target_identifier: ''
-        })
-      } else {
-        const errorData = await response.json()
-        toast.error(errorData.detail || 'Failed to create mapping')
-      }
-    } catch (error) {
-      console.error('Error creating manual mapping:', error)
-      toast.error('Failed to create mapping')
-    }
+    return MappingHandlers.createManualMapping(
+      newMappingForm,
+      showManualMappingDialog,
+      selectedManualMappingPlatform,
+      setNewMappingDialogOpen,
+      setNewMappingForm,
+      loadManualMappings
+    )
   }
 
   const updateManualMapping = async (mappingId: number, targetIdentifier: string) => {
-    try {
-      const authToken = localStorage.getItem('auth_token')
-      if (!authToken) {
-        toast.error('Please log in to update mappings')
-        return
-      }
-
-      const response = await fetch(`${API_BASE}/integrations/manual-mappings/${mappingId}`, {
-        method: 'PUT',
-        headers: {
-          'Authorization': `Bearer ${authToken}`,
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({ target_identifier: targetIdentifier })
-      })
-      
-      if (response.ok) {
-        toast.success('Manual mapping updated successfully')
-        // Reload mappings
-        if (showManualMappingDialog && selectedManualMappingPlatform) {
-          loadManualMappings(selectedManualMappingPlatform)
-        }
-        setEditingMapping(null)
-      } else {
-        const errorData = await response.json()
-        toast.error(errorData.detail || 'Failed to update mapping')
-      }
-    } catch (error) {
-      console.error('Error updating manual mapping:', error)
-      toast.error('Failed to update mapping')
-    }
+    return MappingHandlers.updateManualMapping(
+      mappingId,
+      targetIdentifier,
+      showManualMappingDialog,
+      selectedManualMappingPlatform,
+      setEditingMapping,
+      loadManualMappings
+    )
   }
 
   const deleteManualMapping = async (mappingId: number) => {
-    try {
-      const authToken = localStorage.getItem('auth_token')
-      if (!authToken) {
-        toast.error('Please log in to delete mappings')
-        return
-      }
-
-      const response = await fetch(`${API_BASE}/integrations/manual-mappings/${mappingId}`, {
-        method: 'DELETE',
-        headers: {
-          'Authorization': `Bearer ${authToken}`,
-          'Content-Type': 'application/json'
-        }
-      })
-      
-      if (response.ok) {
-        toast.success('Manual mapping deleted successfully')
-        // Reload mappings
-        if (showManualMappingDialog && selectedManualMappingPlatform) {
-          loadManualMappings(selectedManualMappingPlatform)
-        }
-      } else {
-        const errorData = await response.json()
-        toast.error(errorData.detail || 'Failed to delete mapping')
-      }
-    } catch (error) {
-      console.error('Error deleting manual mapping:', error)
-      toast.error('Failed to delete mapping')
-    }
+    return MappingHandlers.deleteManualMapping(
+      mappingId,
+      showManualMappingDialog,
+      selectedManualMappingPlatform,
+      loadManualMappings
+    )
   }
 
   const filteredIntegrations = integrations.filter(integration => {
@@ -2979,442 +1515,36 @@ export default function IntegrationsPage() {
 
             {/* Add Rootly Integration Form */}
             {addingPlatform === 'rootly' && (
-              <Card className="border-purple-200 max-w-2xl mx-auto">
-                <CardHeader className="p-8">
-                  <div className="flex items-center space-x-3">
-                    <div className="w-10 h-10 bg-purple-100 rounded-lg flex items-center justify-center">
-                      <Image src="/images/rootly-logo-branded.png" alt="Rootly" width={24} height={24} />
-                    </div>
-                    <div>
-                      <CardTitle>Add Rootly Integration</CardTitle>
-                      <CardDescription>Connect your Rootly account to analyze incident data</CardDescription>
-                    </div>
-                  </div>
-                </CardHeader>
-                <CardContent className="space-y-4 p-8 pt-0">
-                  {/* Instructions */}
-                  <div>
-                    <button 
-                      type="button"
-                      onClick={() => setShowRootlyInstructions(!showRootlyInstructions)}
-                      className="flex items-center space-x-2 text-sm text-purple-600 hover:text-purple-700"
-                    >
-                      <HelpCircle className="w-4 h-4" />
-                      <span>How to get your Rootly API token</span>
-                      <ChevronDown className={`w-4 h-4 transition-transform ${showRootlyInstructions ? 'rotate-180' : ''}`} />
-                    </button>
-                    {showRootlyInstructions && (
-                      <div className="mt-4">
-                        <Alert className="border-purple-200 bg-purple-50">
-                          <AlertDescription>
-                            <ol className="space-y-2 text-sm">
-                              <li><strong>1.</strong> Log in to your Rootly account</li>
-                              <li><strong>2.</strong> Navigate to <code className="bg-purple-100 px-1 rounded">Settings → API Keys</code></li>
-                              <li><strong>3.</strong> Click <strong>"Create API Key"</strong></li>
-                              <li><strong>4.</strong> Give it a name (e.g., <strong>"Burnout Detector"</strong>)</li>
-                              <li><strong>5.</strong> Select appropriate permissions (<strong>required:</strong> read access to incidents and users)</li>
-                              <li><strong>6.</strong> Copy the generated token (starts with <strong>"rootly_"</strong>)</li>
-                            </ol>
-                          </AlertDescription>
-                        </Alert>
-                      </div>
-                    )}
-                  </div>
-
-                  {/* Form */}
-                  <Form {...rootlyForm}>
-                    <form onSubmit={rootlyForm.handleSubmit((data) => testConnection('rootly', data.rootlyToken))} className="space-y-4">
-                      <FormField
-                        control={rootlyForm.control}
-                        name="rootlyToken"
-                        render={({ field }) => (
-                          <FormItem>
-                            <FormLabel>Rootly API Token</FormLabel>
-                            <FormControl>
-                              <div className="relative">
-                                <Input
-                                  {...field}
-                                  type={isShowingToken ? "text" : "password"}
-                                  placeholder="rootly_********************************"
-                                  className="pr-20"
-                                />
-                                <div className="absolute inset-y-0 right-0 flex items-center space-x-1 pr-3">
-                                  {field.value && (
-                                    <Button
-                                      type="button"
-                                      variant="ghost"
-                                      size="sm"
-                                      className="h-7 w-7 p-0"
-                                      onClick={() => copyToClipboard(field.value)}
-                                    >
-                                      {copied ? (
-                                        <Check className="h-3 w-3 text-green-600" />
-                                      ) : (
-                                        <Copy className="h-3 w-3 text-slate-400" />
-                                      )}
-                                    </Button>
-                                  )}
-                                  <Button
-                                    type="button"
-                                    variant="ghost"
-                                    size="sm"
-                                    className="h-7 w-7 p-0"
-                                    onClick={() => setIsShowingToken(!isShowingToken)}
-                                  >
-                                    {isShowingToken ? (
-                                      <EyeOff className="h-3 w-3 text-slate-400" />
-                                    ) : (
-                                      <Eye className="h-3 w-3 text-slate-400" />
-                                    )}
-                                  </Button>
-                                </div>
-                              </div>
-                            </FormControl>
-                            <FormDescription>
-                              Token should start with "rootly_" followed by 64 hex characters
-                            </FormDescription>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
-
-                      {/* Connection Status */}
-                      {connectionStatus === 'success' && previewData && (
-                        <>
-                          <Alert className="border-purple-200 bg-purple-50">
-                            <CheckCircle className="h-4 w-4 text-purple-600" />
-                            <AlertDescription className="text-purple-800">
-                              <div className="space-y-2">
-                                <p className="font-semibold">✅ Token validated! Permissions verified.</p>
-                                <p className="text-sm text-purple-700">Ready to add this Rootly integration to your dashboard.</p>
-                                <div className="space-y-1 text-sm">
-                                  <p><span className="font-medium">Organization:</span> {previewData.organization_name}</p>
-                                  <p><span className="font-medium">Users:</span> {previewData.total_users}</p>
-                                  {previewData.permissions && (
-                                    <div className="mt-2">
-                                      <p className="font-medium">Permissions:</p>
-                                      <div className="grid grid-cols-2 gap-2 mt-1">
-                                        <div className="flex items-center">
-                                          {previewData.permissions.users?.access ? (
-                                            <CheckCircle className="w-3 h-3 text-green-600 mr-1" />
-                                          ) : (
-                                            <AlertCircle className="w-3 h-3 text-red-600 mr-1" />
-                                          )}
-                                          <span className="text-xs">Users</span>
-                                        </div>
-                                        <div className="flex items-center">
-                                          {previewData.permissions.incidents?.access ? (
-                                            <CheckCircle className="w-3 h-3 text-green-600 mr-1" />
-                                          ) : (
-                                            <AlertCircle className="w-3 h-3 text-red-600 mr-1" />
-                                          )}
-                                          <span className="text-xs">Incidents</span>
-                                        </div>
-                                      </div>
-                                      {(!previewData.permissions.users?.access || !previewData.permissions.incidents?.access) && (
-                                        <div className="mt-2 p-2 bg-red-50 border border-red-200 rounded text-xs">
-                                          <p className="font-medium text-red-800">Missing permissions:</p>
-                                          {!previewData.permissions.users?.access && (
-                                            <p className="text-red-700">• Users: {previewData.permissions.users?.error}</p>
-                                          )}
-                                          {!previewData.permissions.incidents?.access && (
-                                            <p className="text-red-700">• Incidents: {previewData.permissions.incidents?.error}</p>
-                                          )}
-                                        </div>
-                                      )}
-                                    </div>
-                                  )}
-                                </div>
-                              </div>
-                            </AlertDescription>
-                          </Alert>
-
-                          <FormField
-                            control={rootlyForm.control}
-                            name="nickname"
-                            render={({ field }) => (
-                              <FormItem>
-                                <FormLabel>Integration Name (optional)</FormLabel>
-                                <FormControl>
-                                  <Input
-                                    {...field}
-                                    placeholder={previewData.suggested_name || previewData.organization_name}
-                                  />
-                                </FormControl>
-                                <FormDescription>
-                                  Give this integration a custom name
-                                </FormDescription>
-                              </FormItem>
-                            )}
-                          />
-                        </>
-                      )}
-
-                      {connectionStatus === 'error' && (
-                        <Alert variant="destructive">
-                          <AlertCircle className="h-4 w-4" />
-                          <AlertDescription>
-                            ❌ Invalid API token. Please verify your Rootly token and try again.
-                          </AlertDescription>
-                        </Alert>
-                      )}
-
-                      {connectionStatus === 'duplicate' && duplicateInfo && (
-                        <Alert className="border-yellow-200 bg-yellow-50">
-                          <AlertCircle className="h-4 w-4 text-yellow-600" />
-                          <AlertDescription className="text-yellow-800">
-                            This Rootly account is already connected as "{duplicateInfo.existing_integration?.name || 'Unknown'}".
-                          </AlertDescription>
-                        </Alert>
-                      )}
-
-                      <div className="flex space-x-3">
-                        <Button 
-                          type="submit" 
-                          disabled={isTestingConnection || !isValidRootlyToken(rootlyForm.watch('rootlyToken') || '')}
-                          className="bg-purple-600 hover:bg-purple-700"
-                        >
-                          {isTestingConnection ? (
-                            <>
-                              <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                              Testing Connection...
-                            </>
-                          ) : (
-                            <>
-                              <Shield className="w-4 h-4 mr-2" />
-                              Test Connection
-                            </>
-                          )}
-                        </Button>
-
-                        {connectionStatus === 'success' && previewData?.can_add && (
-                          <Button
-                            type="button"
-                            onClick={() => addIntegration('rootly')}
-                            disabled={isAddingRootly}
-                            className="bg-green-600 hover:bg-green-700"
-                          >
-                            {isAddingRootly ? (
-                              <>
-                                <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                                Adding...
-                              </>
-                            ) : (
-                              <>
-                                <Plus className="w-4 h-4 mr-2" />
-                                Add Integration
-                              </>
-                            )}
-                          </Button>
-                        )}
-                      </div>
-                    </form>
-                  </Form>
-                </CardContent>
-              </Card>
+              <RootlyIntegrationForm
+                form={rootlyForm}
+                onTest={testConnection}
+                onAdd={() => addIntegration('rootly')}
+                connectionStatus={connectionStatus}
+                previewData={previewData}
+                duplicateInfo={duplicateInfo}
+                isTestingConnection={isTestingConnection}
+                isAdding={isAddingRootly}
+                isValidToken={isValidRootlyToken}
+                onCopyToken={copyToClipboard}
+                copied={copied}
+              />
             )}
 
             {/* Add PagerDuty Integration Form */}
             {addingPlatform === 'pagerduty' && (
-              <Card className="border-green-200 max-w-2xl mx-auto">
-                <CardHeader className="p-8">
-                  <div className="flex items-center space-x-3">
-                    <div className="w-10 h-10 bg-green-100 rounded-lg flex items-center justify-center">
-                      <span className="text-green-600 font-bold">PD</span>
-                    </div>
-                    <div>
-                      <CardTitle>Add PagerDuty Integration</CardTitle>
-                      <CardDescription>Connect your PagerDuty account for burnout analysis</CardDescription>
-                    </div>
-                  </div>
-                </CardHeader>
-                <CardContent className="space-y-4 p-8 pt-0">
-                  {/* Instructions */}
-                  <div>
-                    <button 
-                      type="button"
-                      onClick={() => setShowPagerDutyInstructions(!showPagerDutyInstructions)}
-                      className="flex items-center space-x-2 text-sm text-green-600 hover:text-green-700"
-                    >
-                      <HelpCircle className="w-4 h-4" />
-                      <span>How to get your PagerDuty API token</span>
-                      <ChevronDown className={`w-4 h-4 transition-transform ${showPagerDutyInstructions ? 'rotate-180' : ''}`} />
-                    </button>
-                    {showPagerDutyInstructions && (
-                      <div className="mt-4">
-                        <Alert className="border-green-200 bg-green-50">
-                          <AlertDescription>
-                            <ol className="space-y-2 text-sm">
-                              <li><strong>1.</strong> In your PagerDuty account, click on <strong>Integrations</strong> in the top navigation</li>
-                              <li><strong>2.</strong> Look for <strong>API Access Keys</strong> in the dropdown menu</li>
-                              <li><strong>3.</strong> Click <code className="bg-green-100 px-1 rounded">Create API User Token</code> (NOT "Create API Key" - must be user-level)</li>
-                              <li><strong>4.</strong> Give it a description (e.g., <strong>"Burnout Detector"</strong>) and click <strong>Create</strong></li>
-                              <li><strong>5.</strong> Copy the generated token (starts with letters/numbers like <strong>"u+..."</strong>)</li>
-                            </ol>
-                          </AlertDescription>
-                        </Alert>
-                      </div>
-                    )}
-                  </div>
-
-                  {/* Form */}
-                  <Form {...pagerdutyForm}>
-                    <form onSubmit={pagerdutyForm.handleSubmit((data) => testConnection('pagerduty', data.pagerdutyToken))} className="space-y-4">
-                      <FormField
-                        control={pagerdutyForm.control}
-                        name="pagerdutyToken"
-                        render={({ field }) => (
-                          <FormItem>
-                            <FormLabel>PagerDuty API Token</FormLabel>
-                            <FormControl>
-                              <div className="relative">
-                                <Input
-                                  {...field}
-                                  type={isShowingToken ? "text" : "password"}
-                                  placeholder="Enter your PagerDuty API token"
-                                  className="pr-20"
-                                />
-                                <div className="absolute inset-y-0 right-0 flex items-center space-x-1 pr-3">
-                                  {field.value && (
-                                    <Button
-                                      type="button"
-                                      variant="ghost"
-                                      size="sm"
-                                      className="h-7 w-7 p-0"
-                                      onClick={() => copyToClipboard(field.value)}
-                                    >
-                                      {copied ? (
-                                        <Check className="h-3 w-3 text-green-600" />
-                                      ) : (
-                                        <Copy className="h-3 w-3 text-slate-400" />
-                                      )}
-                                    </Button>
-                                  )}
-                                  <Button
-                                    type="button"
-                                    variant="ghost"
-                                    size="sm"
-                                    className="h-7 w-7 p-0"
-                                    onClick={() => setIsShowingToken(!isShowingToken)}
-                                  >
-                                    {isShowingToken ? (
-                                      <EyeOff className="h-3 w-3 text-slate-400" />
-                                    ) : (
-                                      <Eye className="h-3 w-3 text-slate-400" />
-                                    )}
-                                  </Button>
-                                </div>
-                              </div>
-                            </FormControl>
-                            <FormDescription>
-                              Your API token should be 20-32 characters long
-                            </FormDescription>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
-
-                      {/* Connection Status */}
-                      {connectionStatus === 'success' && previewData && (
-                        <>
-                          <Alert className="border-green-200 bg-green-50">
-                            <CheckCircle className="h-4 w-4 text-green-600" />
-                            <AlertDescription className="text-green-800">
-                              <div className="space-y-2">
-                                <p className="font-semibold">✅ Token validated! API access confirmed.</p>
-                                <p className="text-sm text-green-700">Ready to add this PagerDuty integration to your dashboard.</p>
-                                <div className="space-y-1 text-sm">
-                                  <p><span className="font-medium">Organization:</span> {previewData.organization_name}</p>
-                                  <p><span className="font-medium">Users:</span> {previewData.total_users}</p>
-                                  <p><span className="font-medium">Services:</span> {previewData.total_services}</p>
-                                </div>
-                              </div>
-                            </AlertDescription>
-                          </Alert>
-
-                          <FormField
-                            control={pagerdutyForm.control}
-                            name="nickname"
-                            render={({ field }) => (
-                              <FormItem>
-                                <FormLabel>Integration Name (optional)</FormLabel>
-                                <FormControl>
-                                  <Input
-                                    {...field}
-                                    placeholder={previewData.organization_name}
-                                  />
-                                </FormControl>
-                                <FormDescription>
-                                  Give this integration a custom name
-                                </FormDescription>
-                              </FormItem>
-                            )}
-                          />
-                        </>
-                      )}
-
-                      {connectionStatus === 'error' && (
-                        <Alert variant="destructive">
-                          <AlertCircle className="h-4 w-4" />
-                          <AlertDescription>
-                            ❌ Invalid API token. Please verify your PagerDuty token and try again.
-                          </AlertDescription>
-                        </Alert>
-                      )}
-
-                      {connectionStatus === 'duplicate' && duplicateInfo && (
-                        <Alert className="border-yellow-200 bg-yellow-50">
-                          <AlertCircle className="h-4 w-4 text-yellow-600" />
-                          <AlertDescription className="text-yellow-800">
-                            This PagerDuty account is already connected as "{duplicateInfo.existing_integration}".
-                          </AlertDescription>
-                        </Alert>
-                      )}
-
-                      <div className="flex space-x-3">
-                        <Button 
-                          type="submit" 
-                          disabled={isTestingConnection || !isValidPagerDutyToken(pagerdutyForm.watch('pagerdutyToken') || '')}
-                          className="bg-green-600 hover:bg-green-700"
-                        >
-                          {isTestingConnection ? (
-                            <>
-                              <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                              Testing Connection...
-                            </>
-                          ) : (
-                            <>
-                              <Shield className="w-4 h-4 mr-2" />
-                              Test Connection
-                            </>
-                          )}
-                        </Button>
-
-                        {connectionStatus === 'success' && previewData?.can_add && (
-                          <Button
-                            type="button"
-                            onClick={() => addIntegration('pagerduty')}
-                            disabled={isAddingPagerDuty}
-                            className="bg-blue-600 hover:bg-blue-700"
-                          >
-                            {isAddingPagerDuty ? (
-                              <>
-                                <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                                Adding...
-                              </>
-                            ) : (
-                              <>
-                                <Plus className="w-4 h-4 mr-2" />
-                                Add Integration
-                              </>
-                            )}
-                          </Button>
-                        )}
-                      </div>
-                    </form>
-                  </Form>
-                </CardContent>
-              </Card>
+              <PagerDutyIntegrationForm
+                form={pagerdutyForm}
+                onTest={testConnection}
+                onAdd={() => addIntegration('pagerduty')}
+                connectionStatus={connectionStatus}
+                previewData={previewData}
+                duplicateInfo={duplicateInfo}
+                isTestingConnection={isTestingConnection}
+                isAdding={isAddingPagerDuty}
+                isValidToken={isValidPagerDutyToken}
+                onCopyToken={copyToClipboard}
+                copied={copied}
+              />
             )}
 
             {/* Existing Integrations */}
@@ -3716,155 +1846,172 @@ export default function IntegrationsPage() {
           <div className="max-w-2xl mx-auto space-y-6">
             {/* Slack Survey with Tabs */}
             <Card className="border-2 border-purple-200 bg-purple-50/30">
-              <CardHeader className="pb-4">
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center space-x-3">
-                    <div className="w-10 h-10 bg-purple-100 rounded-lg flex items-center justify-center">
-                      <svg className="w-6 h-6" viewBox="0 0 124 124" fill="none">
-                        <path d="M26.3996 78.2003C26.3996 84.7003 21.2996 89.8003 14.7996 89.8003C8.29961 89.8003 3.19961 84.7003 3.19961 78.2003C3.19961 71.7003 8.29961 66.6003 14.7996 66.6003H26.3996V78.2003Z" fill="#E01E5A"/>
-                        <path d="M32.2996 78.2003C32.2996 71.7003 37.3996 66.6003 43.8996 66.6003C50.3996 66.6003 55.4996 71.7003 55.4996 78.2003V109.2C55.4996 115.7 50.3996 120.8 43.8996 120.8C37.3996 120.8 32.2996 115.7 32.2996 109.2V78.2003Z" fill="#E01E5A"/>
-                        <path d="M43.8996 26.4003C37.3996 26.4003 32.2996 21.3003 32.2996 14.8003C32.2996 8.30026 37.3996 3.20026 43.8996 3.20026C50.3996 3.20026 55.4996 8.30026 55.4996 14.8003V26.4003H43.8996Z" fill="#36C5F0"/>
-                        <path d="M43.8996 32.3003C50.3996 32.3003 55.4996 37.4003 55.4996 43.9003C55.4996 50.4003 50.3996 55.5003 43.8996 55.5003H12.8996C6.39961 55.5003 1.29961 50.4003 1.29961 43.9003C1.29961 37.4003 6.39961 32.3003 12.8996 32.3003H43.8996Z" fill="#36C5F0"/>
-                        <path d="M95.5996 43.9003C95.5996 37.4003 100.7 32.3003 107.2 32.3003C113.7 32.3003 118.8 37.4003 118.8 43.9003C118.8 50.4003 113.7 55.5003 107.2 55.5003H95.5996V43.9003Z" fill="#2EB67D"/>
-                        <path d="M89.6996 43.9003C89.6996 50.4003 84.5996 55.5003 78.0996 55.5003C71.5996 55.5003 66.4996 50.4003 66.4996 43.9003V12.9003C66.4996 6.40026 71.5996 1.30026 78.0996 1.30026C84.5996 1.30026 89.6996 6.40026 89.6996 12.9003V43.9003Z" fill="#2EB67D"/>
-                        <path d="M78.0996 95.6003C84.5996 95.6003 89.6996 100.7 89.6996 107.2C89.6996 113.7 84.5996 118.8 78.0996 118.8C71.5996 118.8 66.4996 113.7 66.4996 107.2V95.6003H78.0996Z" fill="#ECB22E"/>
-                        <path d="M78.0996 89.7003C71.5996 89.7003 66.4996 84.6003 66.4996 78.1003C66.4996 71.6003 71.5996 66.5003 78.0996 66.5003H109.1C115.6 66.5003 120.7 71.6003 120.7 78.1003C120.7 84.6003 115.6 89.7003 109.1 89.7003H78.0996Z" fill="#ECB22E"/>
-                      </svg>
+              {loadingSlack ? (
+                <>
+                  <CardHeader className="pb-4">
+                    <div className="flex items-center justify-between animate-pulse">
+                      <div className="flex items-center space-x-3">
+                        <div className="w-10 h-10 bg-gray-200 rounded-lg"></div>
+                        <div className="space-y-2">
+                          <div className="w-32 h-5 bg-gray-200 rounded"></div>
+                          <div className="w-64 h-4 bg-gray-200 rounded"></div>
+                        </div>
+                      </div>
+                      <div className="w-24 h-9 bg-gray-200 rounded-lg"></div>
                     </div>
-                    <div>
-                      <CardTitle className="text-lg text-gray-900">Slack Survey</CardTitle>
-                      <p className="text-sm text-gray-600">Let team members report burnout scores directly in Slack</p>
-                    </div>
-                  </div>
+                  </CardHeader>
+                  <CardContent>
+                    <div className="space-y-6 animate-pulse">
+                      {/* Skeleton for "Connect Slack Workspace" button */}
+                      <div className="flex flex-col items-center justify-center py-8 space-y-3">
+                        <div className="w-64 h-12 bg-gray-200 rounded-lg"></div>
+                        <div className="w-96 h-4 bg-gray-200 rounded"></div>
+                      </div>
 
-                  {/* Slack Connection Status */}
-                  {slackIntegration ? (
-                    <button
-                      onClick={() => setSlackSurveyDisconnectDialogOpen(true)}
-                      disabled={isDisconnectingSlackSurvey}
-                      className="inline-flex items-center space-x-2 bg-green-100 text-green-800 px-4 py-2 rounded-lg text-sm font-medium hover:bg-green-200 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                    >
-                      {isDisconnectingSlackSurvey ? (
-                        <>
-                          <Loader2 className="w-4 h-4 animate-spin" />
-                          <span>Disconnecting...</span>
-                        </>
-                      ) : (
-                        <>
-                          <CheckCircle className="w-4 h-4" />
-                          <span>Connected</span>
-                        </>
-                      )}
-                    </button>
-                  ) : process.env.NEXT_PUBLIC_SLACK_CLIENT_ID ? (
-                    <Button
-                      onClick={() => {
-                        // Official OnCall Burnout Detector Slack App
-                        // This single app can be installed by any organization
-                        const clientId = process.env.NEXT_PUBLIC_SLACK_CLIENT_ID
-                        const backendUrl = process.env.NEXT_PUBLIC_API_BASE_URL
-
-                        if (!backendUrl) {
-                          toast.error('Backend URL not configured. Please contact support.')
-                          return
-                        }
-
-                        // Include organization context in callback URL so backend knows which org is installing
-                        const redirectUri = `${backendUrl}/integrations/slack/oauth/callback`
-                        const scopes = 'commands,chat:write,team:read'
-
-                        // Add state parameter to track which organization is installing
-                        const currentUser = userInfo // Assuming userInfo contains org info
-                        const stateData = {
-                          orgId: currentUser?.organization_id,
-                          userId: currentUser?.id,
-                          email: currentUser?.email
-                        }
-                        const state = currentUser ? btoa(JSON.stringify(stateData)) : ''
-
-                        const slackAuthUrl = `https://slack.com/oauth/v2/authorize?client_id=${clientId}&scope=${scopes}&redirect_uri=${encodeURIComponent(redirectUri)}&state=${encodeURIComponent(state)}`
-
-                        // Show loading state and persist in localStorage
-                        setIsConnectingSlackOAuth(true)
-                        localStorage.setItem('slack_oauth_in_progress', 'true')
-                        toast.info('Redirecting to Slack...')
-
-                        // Use window.location to navigate in same tab so auth token is preserved
-                        window.location.href = slackAuthUrl
-                      }}
-                      disabled={isConnectingSlackOAuth}
-                      className="bg-purple-600 hover:bg-purple-700 text-white px-3 py-1.5 rounded-lg text-sm font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                    >
-                      {isConnectingSlackOAuth ? (
-                        <span className="flex items-center space-x-2">
-                          <Loader2 className="w-4 h-4 animate-spin" />
-                          <span>Connecting...</span>
-                        </span>
-                      ) : (
-                        'Add to Slack'
-                      )}
-                    </Button>
-                  ) : (
-                    <div className="inline-flex items-center space-x-2 bg-gray-100 text-gray-500 px-4 py-2 rounded-lg text-sm font-medium">
-                      <svg className="w-4 h-4" viewBox="0 0 124 124" fill="currentColor">
-                        <path d="M26.3996 78.2003C26.3996 84.7003 21.2996 89.8003 14.7996 89.8003C8.29961 89.8003 3.19961 84.7003 3.19961 78.2003C3.19961 71.7003 8.29961 66.6003 14.7996 66.6003H26.3996V78.2003Z"/>
-                        <path d="M32.2996 78.2003C32.2996 71.7003 37.3996 66.6003 43.8996 66.6003C50.3996 66.6003 55.4996 71.7003 55.4996 78.2003V109.2C55.4996 115.7 50.3996 120.8 43.8996 120.8C37.3996 120.8 32.2996 115.7 32.2996 109.2V78.2003Z"/>
-                        <path d="M43.8996 26.4003C37.3996 26.4003 32.2996 21.3003 32.2996 14.8003C32.2996 8.30026 37.3996 3.20026 43.8996 3.20026C50.3996 3.20026 55.4996 8.30026 55.4996 14.8003V26.4003H43.8996Z"/>
-                      </svg>
-                      <span>Slack App Not Configured</span>
-                    </div>
-                  )}
-                </div>
-              </CardHeader>
-              <CardContent>
-                {loadingSlack ? (
-                  <div className="space-y-6 animate-pulse">
-                    {/* Skeleton for "Connect Slack Workspace" button */}
-                    <div className="flex flex-col items-center justify-center py-8 space-y-3">
-                      <div className="w-64 h-12 bg-gray-200 rounded-lg"></div>
-                      <div className="w-96 h-4 bg-gray-200 rounded"></div>
-                    </div>
-
-                    {/* Skeleton for "How it works" section */}
-                    <div className="space-y-4">
-                      <div className="w-32 h-6 bg-gray-200 rounded"></div>
+                      {/* Skeleton for "How it works" section */}
                       <div className="space-y-4">
-                        <div className="flex items-start space-x-3">
-                          <div className="w-8 h-8 bg-gray-200 rounded-full flex-shrink-0"></div>
-                          <div className="flex-1 space-y-2">
-                            <div className="w-3/4 h-4 bg-gray-200 rounded"></div>
+                        <div className="w-32 h-6 bg-gray-200 rounded"></div>
+                        <div className="space-y-4">
+                          <div className="flex items-start space-x-3">
+                            <div className="w-8 h-8 bg-gray-200 rounded-full flex-shrink-0"></div>
+                            <div className="flex-1 space-y-2">
+                              <div className="w-3/4 h-4 bg-gray-200 rounded"></div>
+                            </div>
                           </div>
-                        </div>
-                        <div className="flex items-start space-x-3">
-                          <div className="w-8 h-8 bg-gray-200 rounded-full flex-shrink-0"></div>
-                          <div className="flex-1 space-y-2">
-                            <div className="w-2/3 h-4 bg-gray-200 rounded"></div>
-                            <div className="w-full h-20 bg-gray-200 rounded-lg mt-2"></div>
+                          <div className="flex items-start space-x-3">
+                            <div className="w-8 h-8 bg-gray-200 rounded-full flex-shrink-0"></div>
+                            <div className="flex-1 space-y-2">
+                              <div className="w-2/3 h-4 bg-gray-200 rounded"></div>
+                              <div className="w-full h-20 bg-gray-200 rounded-lg mt-2"></div>
+                            </div>
                           </div>
-                        </div>
-                        <div className="flex items-start space-x-3">
-                          <div className="w-8 h-8 bg-gray-200 rounded-full flex-shrink-0"></div>
-                          <div className="flex-1 space-y-2">
-                            <div className="w-3/4 h-4 bg-gray-200 rounded"></div>
+                          <div className="flex items-start space-x-3">
+                            <div className="w-8 h-8 bg-gray-200 rounded-full flex-shrink-0"></div>
+                            <div className="flex-1 space-y-2">
+                              <div className="w-3/4 h-4 bg-gray-200 rounded"></div>
+                            </div>
                           </div>
                         </div>
                       </div>
-                    </div>
 
-                    {/* Skeleton for footer */}
-                    <div className="flex items-center justify-between pt-4 border-t">
-                      <div className="flex items-center space-x-2">
-                        <div className="w-4 h-4 bg-gray-200 rounded"></div>
-                        <div className="w-48 h-4 bg-gray-200 rounded"></div>
-                      </div>
+                      {/* Skeleton for footer */}
+                      <div className="flex items-center justify-between pt-4 border-t">
+                        <div className="flex items-center space-x-2">
+                          <div className="w-4 h-4 bg-gray-200 rounded"></div>
+                          <div className="w-48 h-4 bg-gray-200 rounded"></div>
+                        </div>
                       <div className="flex items-center space-x-2">
                         <div className="w-4 h-4 bg-gray-200 rounded"></div>
                         <div className="w-40 h-4 bg-gray-200 rounded"></div>
                       </div>
                     </div>
                   </div>
-                ) : (
-                  <SlackSurveyTabs
+                  </CardContent>
+                </>
+              ) : (
+                <>
+                  <CardHeader className="pb-4">
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center space-x-3">
+                        <div className="w-10 h-10 bg-purple-100 rounded-lg flex items-center justify-center">
+                          <svg className="w-6 h-6" viewBox="0 0 124 124" fill="none">
+                            <path d="M26.3996 78.2003C26.3996 84.7003 21.2996 89.8003 14.7996 89.8003C8.29961 89.8003 3.19961 84.7003 3.19961 78.2003C3.19961 71.7003 8.29961 66.6003 14.7996 66.6003H26.3996V78.2003Z" fill="#E01E5A"/>
+                            <path d="M32.2996 78.2003C32.2996 71.7003 37.3996 66.6003 43.8996 66.6003C50.3996 66.6003 55.4996 71.7003 55.4996 78.2003V109.2C55.4996 115.7 50.3996 120.8 43.8996 120.8C37.3996 120.8 32.2996 115.7 32.2996 109.2V78.2003Z" fill="#E01E5A"/>
+                            <path d="M43.8996 26.4003C37.3996 26.4003 32.2996 21.3003 32.2996 14.8003C32.2996 8.30026 37.3996 3.20026 43.8996 3.20026C50.3996 3.20026 55.4996 8.30026 55.4996 14.8003V26.4003H43.8996Z" fill="#36C5F0"/>
+                            <path d="M43.8996 32.3003C50.3996 32.3003 55.4996 37.4003 55.4996 43.9003C55.4996 50.4003 50.3996 55.5003 43.8996 55.5003H12.8996C6.39961 55.5003 1.29961 50.4003 1.29961 43.9003C1.29961 37.4003 6.39961 32.3003 12.8996 32.3003H43.8996Z" fill="#36C5F0"/>
+                            <path d="M95.5996 43.9003C95.5996 37.4003 100.7 32.3003 107.2 32.3003C113.7 32.3003 118.8 37.4003 118.8 43.9003C118.8 50.4003 113.7 55.5003 107.2 55.5003H95.5996V43.9003Z" fill="#2EB67D"/>
+                            <path d="M89.6996 43.9003C89.6996 50.4003 84.5996 55.5003 78.0996 55.5003C71.5996 55.5003 66.4996 50.4003 66.4996 43.9003V12.9003C66.4996 6.40026 71.5996 1.30026 78.0996 1.30026C84.5996 1.30026 89.6996 6.40026 89.6996 12.9003V43.9003Z" fill="#2EB67D"/>
+                            <path d="M78.0996 95.6003C84.5996 95.6003 89.6996 100.7 89.6996 107.2C89.6996 113.7 84.5996 118.8 78.0996 118.8C71.5996 118.8 66.4996 113.7 66.4996 107.2V95.6003H78.0996Z" fill="#ECB22E"/>
+                            <path d="M78.0996 89.7003C71.5996 89.7003 66.4996 84.6003 66.4996 78.1003C66.4996 71.6003 71.5996 66.5003 78.0996 66.5003H109.1C115.6 66.5003 120.7 71.6003 120.7 78.1003C120.7 84.6003 115.6 89.7003 109.1 89.7003H78.0996Z" fill="#ECB22E"/>
+                          </svg>
+                        </div>
+                        <div>
+                          <CardTitle className="text-lg text-gray-900">Slack Survey</CardTitle>
+                          <p className="text-sm text-gray-600">Let team members report burnout scores directly in Slack</p>
+                        </div>
+                      </div>
+
+                      {/* Slack Connection Status */}
+                      {slackIntegration ? (
+                        <button
+                          onClick={() => setSlackSurveyDisconnectDialogOpen(true)}
+                          disabled={isDisconnectingSlackSurvey}
+                          className="inline-flex items-center space-x-2 bg-green-100 text-green-800 px-4 py-2 rounded-lg text-sm font-medium hover:bg-green-200 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                        >
+                          {isDisconnectingSlackSurvey ? (
+                            <>
+                              <Loader2 className="w-4 h-4 animate-spin" />
+                              <span>Disconnecting...</span>
+                            </>
+                          ) : (
+                            <>
+                              <CheckCircle className="w-4 h-4" />
+                              <span>Connected</span>
+                            </>
+                          )}
+                        </button>
+                      ) : process.env.NEXT_PUBLIC_SLACK_CLIENT_ID ? (
+                        <Button
+                          onClick={() => {
+                            // Official OnCall Burnout Detector Slack App
+                            // This single app can be installed by any organization
+                            const clientId = process.env.NEXT_PUBLIC_SLACK_CLIENT_ID
+                            const backendUrl = process.env.NEXT_PUBLIC_API_BASE_URL
+
+                            if (!backendUrl) {
+                              toast.error('Backend URL not configured. Please contact support.')
+                              return
+                            }
+
+                            // Include organization context in callback URL so backend knows which org is installing
+                            const redirectUri = `${backendUrl}/integrations/slack/oauth/callback`
+                            const scopes = 'commands,chat:write,team:read'
+
+                            // Add state parameter to track which organization is installing
+                            const currentUser = userInfo // Assuming userInfo contains org info
+                            const stateData = {
+                              orgId: currentUser?.organization_id,
+                              userId: currentUser?.id,
+                              email: currentUser?.email
+                            }
+                            const state = currentUser ? btoa(JSON.stringify(stateData)) : ''
+
+                            const slackAuthUrl = `https://slack.com/oauth/v2/authorize?client_id=${clientId}&scope=${scopes}&redirect_uri=${encodeURIComponent(redirectUri)}&state=${encodeURIComponent(state)}`
+
+                            // Show loading state and persist in localStorage
+                            setIsConnectingSlackOAuth(true)
+                            localStorage.setItem('slack_oauth_in_progress', 'true')
+                            toast.info('Redirecting to Slack...')
+
+                            // Use window.location to navigate in same tab so auth token is preserved
+                            window.location.href = slackAuthUrl
+                          }}
+                          disabled={isConnectingSlackOAuth}
+                          className="bg-purple-600 hover:bg-purple-700 text-white px-3 py-1.5 rounded-lg text-sm font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                        >
+                          {isConnectingSlackOAuth ? (
+                            <span className="flex items-center space-x-2">
+                              <Loader2 className="w-4 h-4 animate-spin" />
+                              <span>Connecting...</span>
+                            </span>
+                          ) : (
+                            'Add to Slack'
+                          )}
+                        </Button>
+                      ) : (
+                        <div className="inline-flex items-center space-x-2 bg-gray-100 text-gray-500 px-4 py-2 rounded-lg text-sm font-medium">
+                          <svg className="w-4 h-4" viewBox="0 0 124 124" fill="currentColor">
+                            <path d="M26.3996 78.2003C26.3996 84.7003 21.2996 89.8003 14.7996 89.8003C8.29961 89.8003 3.19961 84.7003 3.19961 78.2003C3.19961 71.7003 8.29961 66.6003 14.7996 66.6003H26.3996V78.2003Z"/>
+                            <path d="M32.2996 78.2003C32.2996 71.7003 37.3996 66.6003 43.8996 66.6003C50.3996 66.6003 55.4996 71.7003 55.4996 78.2003V109.2C55.4996 115.7 50.3996 120.8 43.8996 120.8C37.3996 120.8 32.2996 115.7 32.2996 109.2V78.2003Z"/>
+                            <path d="M43.8996 26.4003C37.3996 26.4003 32.2996 21.3003 32.2996 14.8003C32.2996 8.30026 37.3996 3.20026 43.8996 3.20026C50.3996 3.20026 55.4996 8.30026 55.4996 14.8003V26.4003H43.8996Z"/>
+                          </svg>
+                          <span>Slack App Not Configured</span>
+                        </div>
+                      )}
+                    </div>
+                  </CardHeader>
+                  <CardContent>
+                    <SlackSurveyTabs
                     slackIntegration={slackIntegration}
                     selectedOrganization={selectedOrganization}
                     integrations={integrations}
@@ -3879,8 +2026,9 @@ export default function IntegrationsPage() {
                     loadSlackPermissions={loadSlackPermissions}
                     toast={toast}
                   />
-                )}
-              </CardContent>
+                  </CardContent>
+                </>
+              )}
             </Card>
 
             {/* OLD SLACK SURVEY CONTENT - TO BE REMOVED AFTER TESTING */}
@@ -4336,456 +2484,30 @@ export default function IntegrationsPage() {
           <div className="space-y-6">
             {/* GitHub Token Form */}
             {activeEnhancementTab === 'github' && !githubIntegration && (
-              <Card className="border-gray-200 max-w-2xl mx-auto">
-                <CardHeader className="p-8">
-                  <div className="flex items-center space-x-3">
-                    <div className="w-10 h-10 rounded-lg flex items-center justify-center">
-                      <Image
-                        src="/images/github-logo.png"
-                        alt="GitHub"
-                        width={40}
-                        height={40}
-                        className="h-10 w-10 object-contain"
-                      />
-                    </div>
-                    <div>
-                      <CardTitle>Add GitHub Integration</CardTitle>
-                      <CardDescription>Connect your GitHub account to analyze development patterns</CardDescription>
-                    </div>
-                  </div>
-                </CardHeader>
-                <CardContent className="space-y-4 p-8 pt-0">
-                  {/* Instructions */}
-                  <div>
-                    <button 
-                      type="button"
-                      onClick={() => setShowGithubInstructions(!showGithubInstructions)}
-                      className="flex items-center space-x-2 text-sm text-gray-600 hover:text-gray-700"
-                    >
-                      <HelpCircle className="w-4 h-4" />
-                      <span>How to get your GitHub Personal Access Token</span>
-                      <ChevronDown className={`w-4 h-4 transition-transform ${showGithubInstructions ? 'rotate-180' : ''}`} />
-                    </button>
-                    {showGithubInstructions && (
-                      <div className="mt-4">
-                        <Alert className="border-gray-200 bg-gray-50">
-                          <AlertDescription>
-                            <div className="space-y-4">
-                              <div>
-                                <h4 className="font-medium text-gray-900 mb-2"><strong>Step 1:</strong> Go to GitHub Settings</h4>
-                                <p className="text-sm text-gray-600 mb-2">
-                                  Navigate to <strong>GitHub → Settings → Developer settings → Personal access tokens → Tokens (classic)</strong>
-                                </p>
-                                <a 
-                                  href="https://github.com/settings/tokens" 
-                                  target="_blank" 
-                                  rel="noopener noreferrer"
-                                  className="inline-flex items-center text-sm text-blue-600 hover:underline"
-                                >
-                                  Open GitHub Settings <ExternalLink className="w-3 h-3 ml-1" />
-                                </a>
-                              </div>
-                              
-                              <div>
-                                <h4 className="font-medium text-gray-900 mb-2"><strong>Step 2:</strong> Generate New Token</h4>
-                                <p className="text-sm text-gray-600 mb-2">Click <strong>"Generate new token (classic)"</strong> and configure:</p>
-                                <ul className="text-sm text-gray-600 space-y-1 ml-4">
-                                  <li>• <strong>Note:</strong> Give it a descriptive name (e.g., "Burnout Detector")</li>
-                                  <li>• <strong>Expiration:</strong> Set an appropriate expiration date</li>
-                                </ul>
-                              </div>
-                              
-                              <div>
-                                <h4 className="font-medium text-gray-900 mb-2"><strong>Step 3:</strong> Select Required Scopes</h4>
-                                <p className="text-sm text-gray-600 mb-2">Select these <strong>permissions:</strong></p>
-                                <ul className="text-sm text-gray-600 space-y-1 ml-4">
-                                  <li>• <code className="bg-gray-200 px-1 rounded">repo</code> - Full repository access</li>
-                                  <li>• <code className="bg-gray-200 px-1 rounded">read:user</code> - Read user profile information</li>
-                                  <li>• <code className="bg-gray-200 px-1 rounded">read:org</code> - Read organization membership</li>
-                                </ul>
-                              </div>
-                              
-                              <div>
-                                <h4 className="font-medium text-gray-900 mb-2"><strong>Step 4:</strong> Generate and Copy Token</h4>
-                                <p className="text-sm text-gray-600">
-                                  Click <strong>"Generate token"</strong> and immediately copy the token (starts with <code className="bg-gray-200 px-1 rounded">ghp_</code>). 
-                                  <strong>You won't be able to see it again!</strong>
-                                </p>
-                              </div>
-                            </div>
-                          </AlertDescription>
-                        </Alert>
-                      </div>
-                    )}
-                  </div>
-
-                  <div className="space-y-2">
-                    <label htmlFor="github-token" className="text-sm font-medium">GitHub Personal Access Token</label>
-                    <div className="relative">
-                      <Input
-                        id="github-token"
-                        type={showGithubToken ? "text" : "password"}
-                        placeholder="ghp_xxxxxxxxxxxxxxxxxxxx"
-                        className="pr-10"
-                        value={githubToken}
-                        onChange={(e) => setGithubToken(e.target.value)}
-                      />
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
-                        onClick={() => setShowGithubToken(!showGithubToken)}
-                      >
-                        {showGithubToken ? (
-                          <EyeOff className="h-4 w-4 text-gray-400" />
-                        ) : (
-                          <Eye className="h-4 w-4 text-gray-400" />
-                        )}
-                      </Button>
-                    </div>
-                    <p className="text-sm text-gray-500">
-                      Token should start with "ghp_" followed by 36 characters
-                    </p>
-                  </div>
-                  <Button 
-                    className="bg-gray-900 hover:bg-gray-800 text-white"
-                    onClick={() => githubToken && handleGitHubConnect(githubToken)}
-                    disabled={!githubToken || isConnectingGithub}
-                  >
-                    {isConnectingGithub ? (
-                      <>
-                        <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                        Connecting...
-                      </>
-                    ) : (
-                      'Connect GitHub'
-                    )}
-                  </Button>
-                </CardContent>
-              </Card>
+              <GitHubIntegrationCard
+                onConnect={handleGitHubConnect}
+                isConnecting={isConnectingGithub}
+              />
             )}
 
             {/* Slack Webhook Form */}
             {activeEnhancementTab === 'slack' && !slackIntegration && (
-              <Card className="border-purple-200 max-w-2xl mx-auto">
-                <CardHeader className="p-8">
-                  <div className="flex items-center space-x-3">
-                    <div className="w-10 h-10 rounded-lg flex items-center justify-center">
-                      <Image
-                        src="/images/slack-logo.png"
-                        alt="Slack"
-                        width={40}
-                        height={40}
-                        className="h-10 w-10 object-contain"
-                      />
-                    </div>
-                    <div>
-                      <CardTitle>Add Slack Integration</CardTitle>
-                      <CardDescription>Connect your Slack workspace to analyze communication patterns</CardDescription>
-                    </div>
-                  </div>
-                </CardHeader>
-                <CardContent className="space-y-4 p-8 pt-0">
-                  {/* Instructions */}
-                  <div>
-                    <button 
-                      type="button"
-                      onClick={() => setShowSlackInstructions(!showSlackInstructions)}
-                      className="flex items-center space-x-2 text-sm text-purple-600 hover:text-purple-700"
-                    >
-                      <HelpCircle className="w-4 h-4" />
-                      <span>How to get your Slack credentials</span>
-                      <ChevronDown className={`w-4 h-4 transition-transform ${showSlackInstructions ? 'rotate-180' : ''}`} />
-                    </button>
-                    {showSlackInstructions && (
-                      <div className="mt-4">
-                        <Alert className="border-purple-200 bg-purple-50">
-                          <AlertDescription>
-                            <div className="space-y-4">
-                              <div>
-                                <h4 className="font-medium text-purple-900 mb-2"><strong>Step 1:</strong> Create a Slack App</h4>
-                                <p className="text-sm text-purple-800 mb-2">
-                                  Go to the <strong>Slack API website</strong> and create a new app:
-                                </p>
-                                <a 
-                                  href="https://api.slack.com/apps" 
-                                  target="_blank" 
-                                  rel="noopener noreferrer"
-                                  className="inline-flex items-center text-sm text-blue-600 hover:underline"
-                                >
-                                  Create Slack App <ExternalLink className="w-3 h-3 ml-1" />
-                                </a>
-                                <p className="text-sm text-purple-800 mt-2">Click "Create New App" → "From scratch" → Enter app name and select your workspace</p>
-                              </div>
-                              
-                              <div>
-                                <h4 className="font-medium text-purple-900 mb-2">Step 2: Configure Incoming Webhooks</h4>
-                                <p className="text-sm text-purple-800 mb-2">In your app settings:</p>
-                                <ul className="text-sm text-purple-800 space-y-1 ml-4">
-                                  <li>• Go to "Incoming Webhooks" in the sidebar</li>
-                                  <li>• Toggle "Activate Incoming Webhooks" to <strong>On</strong></li>
-                                  <li>• Click "Add New Webhook to Workspace"</li>
-                                  <li>• Select a channel and click "Allow"</li>
-                                  <li>• Copy the webhook URL (starts with <code className="bg-purple-200 px-1 rounded">https://hooks.slack.com/</code>)</li>
-                                </ul>
-                              </div>
-                              
-                              <div>
-                                <h4 className="font-medium text-purple-900 mb-2">Step 3: Add Bot Token Scopes</h4>
-                                <p className="text-sm text-purple-800 mb-2">In "OAuth & Permissions" → "Scopes" → "Bot Token Scopes", add these <strong>3 required scopes</strong>:</p>
-                                <ul className="text-sm text-purple-800 space-y-1 ml-4">
-                                  <li>• <code className="bg-purple-200 px-1 rounded">channels:read</code> - View basic channel information</li>
-                                  <li>• <code className="bg-purple-200 px-1 rounded">channels:history</code> - Read public channel messages</li>
-                                  <li>• <code className="bg-purple-200 px-1 rounded">users:read</code> - View user information</li>
-                                </ul>
-                                <div className="mt-2 p-2 bg-amber-100 border border-amber-300 rounded text-xs text-amber-800">
-                                  <strong>Important:</strong> After adding scopes, you MUST reinstall the app to your workspace for changes to take effect.
-                                </div>
-                              </div>
-                              
-                              <div>
-                                <h4 className="font-medium text-purple-900 mb-2">Step 4: Install App and Get Bot Token</h4>
-                                <ul className="text-sm text-purple-800 space-y-1 ml-4">
-                                  <li>• Click "Install to Workspace" at the top of OAuth & Permissions</li>
-                                  <li>• Review permissions and click "Allow"</li>
-                                  <li>• Copy the "Bot User OAuth Token" (starts with <code className="bg-purple-200 px-1 rounded">xoxb-</code>)</li>
-                                </ul>
-                              </div>
-                              
-                              <div>
-                                <h4 className="font-medium text-purple-900 mb-2">Step 5: Add Bot to Channels</h4>
-                                <p className="text-sm text-purple-800 mb-2">After setup, add the bot to relevant channels:</p>
-                                <ul className="text-sm text-purple-800 space-y-1 ml-4">
-                                  <li>• Go to each channel you want analyzed in Slack</li>
-                                  <li>• Type <code className="bg-purple-200 px-1 rounded">@Burnout Detector</code> and invite the bot</li>
-                                  <li>• The bot must be in channels to read message history</li>
-                                </ul>
-                                <div className="mt-2 p-2 bg-red-100 border border-red-300 rounded text-xs text-red-800">
-                                  <strong>Required:</strong> Bot permissions will show "Bot not in channels" until you add it to at least one channel.
-                                </div>
-                              </div>
-                              
-                              <div className="bg-purple-100 border border-purple-300 rounded p-3">
-                                <p className="text-sm text-purple-800">
-                                  <strong>Note:</strong> You'll need both the webhook URL and bot token. The webhook is for sending notifications, 
-                                  and the bot token is for reading messages and user data.
-                                </p>
-                              </div>
-                            </div>
-                          </AlertDescription>
-                        </Alert>
-                      </div>
-                    )}
-                  </div>
-
-                  <div className="space-y-2">
-                    <label htmlFor="slack-webhook" className="text-sm font-medium">Slack Webhook URL</label>
-                    <div className="relative">
-                      <Input
-                        id="slack-webhook"
-                        type={showSlackWebhook ? "text" : "password"}
-                        placeholder="https://hooks.slack.com/services/..."
-                        className="pr-10"
-                        value={slackWebhookUrl}
-                        onChange={(e) => setSlackWebhookUrl(e.target.value)}
-                      />
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
-                        onClick={() => setShowSlackWebhook(!showSlackWebhook)}
-                      >
-                        {showSlackWebhook ? (
-                          <EyeOff className="h-4 w-4 text-gray-400" />
-                        ) : (
-                          <Eye className="h-4 w-4 text-gray-400" />
-                        )}
-                      </Button>
-                    </div>
-                    <p className="text-sm text-gray-500">
-                      URL should start with "https://hooks.slack.com/services/"
-                    </p>
-                  </div>
-                  <div className="space-y-2">
-                    <label htmlFor="slack-token" className="text-sm font-medium">Slack Bot Token</label>
-                    <div className="relative">
-                      <Input
-                        id="slack-token"
-                        type={showSlackToken ? "text" : "password"}
-                        placeholder="xoxb-xxxxxxxxxxxx-xxxxxxxxxxxx"
-                        className="pr-10"
-                        value={slackBotToken}
-                        onChange={(e) => setSlackBotToken(e.target.value)}
-                      />
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
-                        onClick={() => setShowSlackToken(!showSlackToken)}
-                      >
-                        {showSlackToken ? (
-                          <EyeOff className="h-4 w-4 text-gray-400" />
-                        ) : (
-                          <Eye className="h-4 w-4 text-gray-400" />
-                        )}
-                      </Button>
-                    </div>
-                    <p className="text-sm text-gray-500">
-                      Token should start with "xoxb-" followed by your bot token
-                    </p>
-                  </div>
-                  <Button 
-                    className="bg-purple-600 hover:bg-purple-700 text-white"
-                    onClick={() => slackWebhookUrl && slackBotToken && handleSlackConnect(slackWebhookUrl, slackBotToken)}
-                    disabled={!slackWebhookUrl || !slackBotToken || isConnectingSlack}
-                  >
-                    {isConnectingSlack ? (
-                      <>
-                        <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                        Connecting...
-                      </>
-                    ) : (
-                      'Connect Slack'
-                    )}
-                  </Button>
-                </CardContent>
-              </Card>
+              <SlackIntegrationCard
+                onConnect={handleSlackConnect}
+                isConnecting={isConnectingSlack}
+              />
             )}
 
             {/* Connected GitHub Status */}
             {activeEnhancementTab === 'github' && githubIntegration && (
-              <Card className="border-green-200 bg-green-50 max-w-2xl mx-auto">
-                <CardHeader className="p-8">
-                  <div className="flex items-center justify-between">
-                    <div className="flex items-center space-x-3">
-                      <div className="w-10 h-10 rounded-lg flex items-center justify-center">
-                        <Image
-                          src="/images/github-logo.png"
-                          alt="GitHub"
-                          width={40}
-                          height={40}
-                          className="h-10 w-10 object-contain"
-                        />
-                      </div>
-                      <div>
-                        <CardTitle>GitHub Connected</CardTitle>
-                        <div className="space-y-1 text-sm text-muted-foreground">
-                          <div>Username: {githubIntegration.github_username}</div>
-                          {!githubIntegration.is_beta && (
-                            <div>Token: {githubIntegration.token_preview}</div>
-                          )}
-                        </div>
-                      </div>
-                    </div>
-                    <div className="flex items-center space-x-2">
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        onClick={() => openMappingDrawer('github')}
-                        disabled={loadingMappingData}
-                        className="bg-blue-50 text-blue-700 border-blue-200 hover:bg-blue-100 hover:text-blue-800 hover:border-blue-300"
-                        title="View and manage GitHub user mappings"
-                      >
-                        {loadingMappingData && selectedMappingPlatform === 'github' ? (
-                          <>
-                            <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                            Loading...
-                          </>
-                        ) : (
-                          <>
-                            <Users className="w-4 h-4 mr-2" />
-                            View Mappings
-                          </>
-                        )}
-                      </Button>
-                      {githubIntegration.is_beta ? (
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          onClick={handleGitHubTest}
-                        >
-                          <TestTube className="w-4 h-4 mr-1" />
-                          Test Connection
-                        </Button>
-                      ) : (
-                        <Button
-                          size="sm"
-                          variant="ghost"
-                          onClick={() => setGithubDisconnectDialogOpen(true)}
-                          className="h-8 w-8 p-0 text-red-600 hover:text-red-700 hover:bg-red-50"
-                        >
-                          <Trash2 className="w-4 h-4" />
-                        </Button>
-                      )}
-                    </div>
-                  </div>
-                </CardHeader>
-                <CardContent className="p-8 pt-0">
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
-                    <div className="flex items-center space-x-2">
-                      <Key className="w-4 h-4 text-gray-400" />
-                      <div>
-                        <div className="font-medium">Token Source</div>
-                        <div className="text-gray-600">
-                          {githubIntegration.is_beta 
-                            ? "Beta" 
-                            : githubIntegration.token_source === "oauth" 
-                              ? "OAuth" 
-                              : "Personal Access Token"
-                          }
-                        </div>
-                      </div>
-                    </div>
-                    <div className="flex items-center space-x-2">
-                      <Calendar className="w-4 h-4 text-gray-400" />
-                      <div>
-                        <div className="font-medium">Connected</div>
-                        <div className="text-gray-600">{new Date(githubIntegration.connected_at).toLocaleDateString()}</div>
-                      </div>
-                    </div>
-                    <div className="flex items-center space-x-2">
-                      <Building className="w-4 h-4 text-gray-400" />
-                      <div>
-                        <div className="font-medium">Organizations</div>
-                        <div className="text-gray-600">
-                          {githubIntegration.organizations && githubIntegration.organizations.length > 0 
-                            ? githubIntegration.organizations.join(', ') 
-                            : 'None'}
-                        </div>
-                      </div>
-                    </div>
-                    <div className="flex items-center space-x-2">
-                      <Clock className="w-4 h-4 text-gray-400" />
-                      <div>
-                        <div className="font-medium">Last Updated</div>
-                        <div className="text-gray-600">{new Date(githubIntegration.last_updated).toLocaleDateString()}</div>
-                      </div>
-                    </div>
-                  </div>
-                  
-                  {/* Beta Access Information */}
-                  {githubIntegration.is_beta && (
-                    <div className="mt-4 p-4 bg-blue-50 rounded-lg border border-blue-200">
-                      <div className="flex items-start space-x-2">
-                        <div className="w-5 h-5 text-blue-600 mt-0.5">
-                          <CheckCircle className="w-5 h-5" />
-                        </div>
-                        <div className="flex-1 text-sm">
-                          <div className="font-medium text-blue-800 mb-1">Beta Access Enabled</div>
-                          <div className="text-blue-700">
-                            You're using a shared GitHub integration for testing purposes. 
-                            No personal token setup required.
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  )}
-
-                </CardContent>
-              </Card>
+              <GitHubConnectedCard
+                integration={githubIntegration}
+                onDisconnect={() => setGithubDisconnectDialogOpen(true)}
+                onTest={handleGitHubTest}
+                onViewMappings={() => openMappingDrawer('github')}
+                loadingMappings={loadingMappingData}
+                selectedMappingPlatform={selectedMappingPlatform}
+              />
             )}
 
             {/* Connected Slack Status */}
@@ -5778,170 +3500,30 @@ export default function IntegrationsPage() {
       </Dialog>
 
       {/* New Manual Mapping Dialog */}
-      <Dialog open={newMappingDialogOpen} onOpenChange={setNewMappingDialogOpen}>
-        <DialogContent className="max-w-2xl">
-          <DialogHeader>
-            <DialogTitle className="flex items-center space-x-2">
-              <Plus className="w-5 h-5" />
-              <span>Create New Manual Mapping</span>
-            </DialogTitle>
-            <DialogDescription>
-              Create a manual mapping between a source platform user and {selectedManualMappingPlatform === 'github' ? 'GitHub' : 'Slack'} account.
-            </DialogDescription>
-          </DialogHeader>
-
-          <div className="space-y-4">
-            <div className="grid grid-cols-2 gap-4">
-              <div className="space-y-2">
-                <label className="text-sm font-medium">Source Platform</label>
-                <Select 
-                  value={newMappingForm.source_platform} 
-                  onValueChange={(value) => setNewMappingForm(prev => ({...prev, source_platform: value}))}
-                >
-                  <SelectTrigger>
-                    <SelectValue placeholder="Select source platform" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="rootly">Rootly</SelectItem>
-                    <SelectItem value="pagerduty">PagerDuty</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-              
-              <div className="space-y-2">
-                <label className="text-sm font-medium">Target Platform</label>
-                <Select 
-                  value={newMappingForm.target_platform} 
-                  onValueChange={(value) => setNewMappingForm(prev => ({...prev, target_platform: value}))}
-                >
-                  <SelectTrigger>
-                    <SelectValue placeholder="Select target platform" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="github">GitHub</SelectItem>
-                    <SelectItem value="slack">Slack</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-            </div>
-
-            <div className="space-y-2">
-              <label className="text-sm font-medium">Source Identifier</label>
-              <Input
-                placeholder="e.g., john.doe@company.com or John Doe"
-                value={newMappingForm.source_identifier}
-                onChange={(e) => setNewMappingForm(prev => ({...prev, source_identifier: e.target.value}))}
-              />
-              <p className="text-xs text-gray-500">
-                The email or name as it appears in {newMappingForm.source_platform} incidents
-              </p>
-            </div>
-
-            <div className="space-y-2">
-              <label className="text-sm font-medium">Target Identifier</label>
-              <Input
-                placeholder={
-                  newMappingForm.target_platform === 'github' 
-                    ? "e.g., johndoe or john-doe-123"
-                    : "e.g., U1234567890 or @johndoe"
-                }
-                value={newMappingForm.target_identifier}
-                onChange={(e) => setNewMappingForm(prev => ({...prev, target_identifier: e.target.value}))}
-              />
-              <p className="text-xs text-gray-500">
-                The {newMappingForm.target_platform === 'github' ? 'GitHub username' : 'Slack user ID or @username'}
-              </p>
-            </div>
-          </div>
-
-          <DialogFooter>
-            <Button 
-              variant="outline" 
-              onClick={() => setNewMappingDialogOpen(false)}
-            >
-              Cancel
-            </Button>
-            <Button 
-              onClick={createManualMapping}
-              disabled={!newMappingForm.source_identifier || !newMappingForm.target_identifier}
-            >
-              Create Mapping
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <NewMappingDialog
+        open={newMappingDialogOpen}
+        onOpenChange={setNewMappingDialogOpen}
+        form={newMappingForm}
+        onFormChange={setNewMappingForm}
+        selectedPlatform={selectedManualMappingPlatform}
+        onCreateMapping={createManualMapping}
+      />
 
       {/* GitHub Disconnect Confirmation Dialog */}
-      <Dialog open={githubDisconnectDialogOpen} onOpenChange={setGithubDisconnectDialogOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Disconnect GitHub Integration</DialogTitle>
-            <DialogDescription>
-              Are you sure you want to disconnect your GitHub integration? 
-              This will remove access to your GitHub data and you'll need to reconnect to use GitHub features again.
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => setGithubDisconnectDialogOpen(false)}
-              disabled={isDisconnectingGithub}
-            >
-              Cancel
-            </Button>
-            <Button
-              variant="destructive"
-              onClick={handleGitHubDisconnect}
-              disabled={isDisconnectingGithub}
-            >
-              {isDisconnectingGithub ? (
-                <>
-                  <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                  Disconnecting...
-                </>
-              ) : (
-                "Disconnect GitHub"
-              )}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <GitHubDisconnectDialog
+        open={githubDisconnectDialogOpen}
+        onOpenChange={setGithubDisconnectDialogOpen}
+        isDisconnecting={isDisconnectingGithub}
+        onConfirmDisconnect={handleGitHubDisconnect}
+      />
 
       {/* Slack Disconnect Confirmation Dialog */}
-      <Dialog open={slackDisconnectDialogOpen} onOpenChange={setSlackDisconnectDialogOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Disconnect Slack Integration</DialogTitle>
-            <DialogDescription>
-              Are you sure you want to disconnect your Slack integration?
-              This will remove access to your Slack workspace data and you'll need to reconnect to use Slack features again.
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => setSlackDisconnectDialogOpen(false)}
-              disabled={isDisconnectingSlack}
-            >
-              Cancel
-            </Button>
-            <Button
-              variant="destructive"
-              onClick={handleSlackDisconnect}
-              disabled={isDisconnectingSlack}
-            >
-              {isDisconnectingSlack ? (
-                <>
-                  <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                  Disconnecting...
-                </>
-              ) : (
-                "Disconnect Slack"
-              )}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <SlackDisconnectDialog
+        open={slackDisconnectDialogOpen}
+        onOpenChange={setSlackDisconnectDialogOpen}
+        isDisconnecting={isDisconnectingSlack}
+        onConfirmDisconnect={handleSlackDisconnect}
+      />
 
       {/* Slack Survey Workspace Info & Disconnect Dialog */}
       <Dialog open={slackSurveyDisconnectDialogOpen} onOpenChange={setSlackSurveyDisconnectDialogOpen}>
@@ -6114,265 +3696,39 @@ export default function IntegrationsPage() {
       </Dialog>
 
       {/* Delete Confirmation Dialog */}
-      <Dialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Delete Integration</DialogTitle>
-            <DialogDescription>
-              Are you sure you want to delete "{integrationToDelete?.name}"? 
-              This action cannot be undone.
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => {
-                setDeleteDialogOpen(false)
-                setIntegrationToDelete(null)
-              }}
-            >
-              Cancel
-            </Button>
-            <Button
-              variant="destructive"
-              onClick={deleteIntegration}
-              disabled={isDeleting}
-            >
-              {isDeleting ? (
-                <>
-                  <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                  Deleting...
-                </>
-              ) : (
-                "Delete Integration"
-              )}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <DeleteIntegrationDialog
+        open={deleteDialogOpen}
+        onOpenChange={setDeleteDialogOpen}
+        integration={integrationToDelete}
+        isDeleting={isDeleting}
+        onConfirmDelete={deleteIntegration}
+        onCancel={() => {
+          setDeleteDialogOpen(false)
+          setIntegrationToDelete(null)
+        }}
+      />
 
       {/* Organization Management Modal */}
-      <Dialog open={showInviteModal} onOpenChange={setShowInviteModal}>
-        <DialogContent className="max-w-4xl max-h-[80vh] overflow-y-auto">
-          <DialogHeader>
-            <DialogTitle className="flex items-center space-x-2">
-              <Users className="w-5 h-5" />
-              <span>Organization Management</span>
-            </DialogTitle>
-            <DialogDescription>
-              Invite new members and manage your organization
-            </DialogDescription>
-          </DialogHeader>
-
-          {/* Role descriptions - at the top of modal */}
-          <div className="mt-4 px-4 py-3 bg-gradient-to-r from-purple-50 to-blue-50 rounded-lg">
-            <div className="space-y-1.5 text-xs">
-              <div className="flex items-baseline space-x-2">
-                <span className="font-semibold text-gray-900 min-w-[80px]">Org Admin</span>
-                <span className="text-gray-700">Everything a Manager can do, plus manage integrations, invite members, and configure settings</span>
-              </div>
-              <div className="flex items-baseline space-x-2">
-                <span className="font-semibold text-gray-900 min-w-[80px]">Manager</span>
-                <span className="text-gray-700">Full access to view team burnout data, run analyses, and send surveys</span>
-              </div>
-            </div>
-          </div>
-
-          <div className="space-y-6">
-            {/* Invite New Member Section */}
-            <div className="p-6 border rounded-lg bg-gradient-to-br from-purple-50 to-white">
-              <div className="flex items-start space-x-4">
-                <div className="flex-shrink-0 w-10 h-10 bg-purple-100 rounded-lg flex items-center justify-center">
-                  <Mail className="w-5 h-5 text-purple-600" />
-                </div>
-                <div className="flex-1 space-y-4">
-                  <div>
-                    <h3 className="text-lg font-semibold text-gray-900">Invite Team Member</h3>
-                    <p className="text-sm text-gray-500 mt-1">Send an invitation to join your organization</p>
-                  </div>
-
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                    <div>
-                      <label htmlFor="invite-email" className="block text-sm font-medium text-gray-700 mb-1.5">
-                        Email Address
-                      </label>
-                      <Input
-                        id="invite-email"
-                        type="email"
-                        placeholder="colleague@company.com"
-                        value={inviteEmail}
-                        onChange={(e) => setInviteEmail(e.target.value)}
-                        className="w-full"
-                      />
-                    </div>
-                    <div>
-                      <label htmlFor="invite-role" className="block text-sm font-medium text-gray-700 mb-1.5">
-                        Role
-                      </label>
-                      <select
-                        id="invite-role"
-                        value={inviteRole}
-                        onChange={(e) => setInviteRole(e.target.value)}
-                        className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple-500 bg-white"
-                      >
-                        <option value="manager">Manager</option>
-                        <option value="org_admin">Org Admin</option>
-                      </select>
-                    </div>
-                  </div>
-
-                  <Button
-                    onClick={handleInvite}
-                    disabled={isInviting || !inviteEmail.trim()}
-                    className="w-full md:w-auto bg-purple-600 hover:bg-purple-700"
-                  >
-                    {isInviting ? (
-                      <>
-                        <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                        Sending Invitation...
-                      </>
-                    ) : (
-                      <>
-                        <Mail className="w-4 h-4 mr-2" />
-                        Send Invitation
-                      </>
-                    )}
-                  </Button>
-                </div>
-              </div>
-            </div>
-
-            {/* Current Members & Pending Invitations */}
-            {loadingOrgData ? (
-              <div className="text-center py-8">
-                <Loader2 className="w-8 h-8 mx-auto mb-4 animate-spin text-gray-400" />
-                <p className="text-gray-500">Loading organization data...</p>
-              </div>
-            ) : (
-              <div className="space-y-6">
-                {/* Current Members */}
-                {orgMembers.length > 0 && (
-                  <div>
-                    <h3 className="text-lg font-medium mb-3 flex items-center space-x-2">
-                      <Users className="w-5 h-5" />
-                      <span>Organization Members ({orgMembers.length})</span>
-                    </h3>
-                    <div className="border rounded-lg overflow-hidden">
-                      <div className="bg-gray-50 px-4 py-2 border-b">
-                        <div className="grid grid-cols-3 gap-4 text-sm font-medium text-gray-700">
-                          <div>Name</div>
-                          <div>Email</div>
-                          <div>Role</div>
-                        </div>
-                      </div>
-                      <div className="max-h-60 overflow-y-auto">
-                        {orgMembers.map((member: any) => (
-                          <div key={member.id} className="px-4 py-3 border-b last:border-b-0 bg-white hover:bg-gray-50">
-                            <div className="grid grid-cols-3 gap-4 text-sm items-center">
-                              <div className="font-medium text-gray-900">
-                                {member.name}
-                                {member.is_current_user && (
-                                  <span className="ml-2 text-xs bg-blue-100 text-blue-800 px-2 py-1 rounded">You</span>
-                                )}
-                              </div>
-                              <div className="text-gray-600">{member.email}</div>
-                              <div>
-                                {member.is_current_user ? (
-                                  <span className="inline-block px-2 py-1 text-xs rounded-full bg-green-100 text-green-800 capitalize">
-                                    {member.role?.replace('_', ' ') || 'member'}
-                                  </span>
-                                ) : (
-                                  <select
-                                    value={member.role || 'manager'}
-                                    onChange={(e) => handleRoleChange(member.id, e.target.value)}
-                                    className="text-xs px-2 py-1 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple-500 bg-white"
-                                    disabled={userInfo?.role !== 'org_admin'}
-                                  >
-                                    <option value="manager">Manager</option>
-                                    <option value="org_admin">Org Admin</option>
-                                  </select>
-                                )}
-                              </div>
-                            </div>
-                          </div>
-                        ))}
-                      </div>
-                    </div>
-                  </div>
-                )}
-
-                {/* Pending Invitations */}
-                {pendingInvitations.length > 0 && (
-                  <div>
-                    <h3 className="text-lg font-medium mb-3 flex items-center space-x-2">
-                      <Mail className="w-5 h-5" />
-                      <span>Pending Invitations ({pendingInvitations.length})</span>
-                    </h3>
-                    <div className="border rounded-lg overflow-hidden">
-                      <div className="bg-gray-50 px-4 py-2 border-b">
-                        <div className="grid grid-cols-5 gap-4 text-sm font-medium text-gray-700">
-                          <div>Email</div>
-                          <div>Role</div>
-                          <div>Invited By</div>
-                          <div>Sent</div>
-                          <div>Expires</div>
-                        </div>
-                      </div>
-                      <div className="max-h-60 overflow-y-auto">
-                        {pendingInvitations.map((invitation: any) => (
-                          <div key={invitation.id} className="px-4 py-3 border-b last:border-b-0 bg-yellow-50">
-                            <div className="grid grid-cols-5 gap-4 text-sm">
-                              <div className="font-medium text-gray-900">{invitation.email}</div>
-                              <div>
-                                <span className="inline-block px-2 py-1 text-xs rounded-full bg-yellow-100 text-yellow-800 capitalize">
-                                  {invitation.role?.replace('_', ' ') || 'member'}
-                                </span>
-                              </div>
-                              <div className="text-gray-600">{invitation.invited_by?.name || 'Unknown'}</div>
-                              <div className="text-gray-500 text-xs">
-                                {new Date(invitation.created_at).toLocaleDateString()}
-                              </div>
-                              <div className="text-gray-500 text-xs">
-                                {invitation.is_expired ? (
-                                  <span className="text-red-600">Expired</span>
-                                ) : (
-                                  new Date(invitation.expires_at).toLocaleDateString()
-                                )}
-                              </div>
-                            </div>
-                          </div>
-                        ))}
-                      </div>
-                    </div>
-                  </div>
-                )}
-
-                {/* Empty State */}
-                {!loadingOrgData && orgMembers.length === 0 && pendingInvitations.length === 0 && (
-                  <div className="text-center py-8 text-gray-500">
-                    <Users className="w-12 h-12 mx-auto mb-4 opacity-50" />
-                    <p>No organization members or pending invitations found</p>
-                    <p className="text-sm mt-1">Start by inviting team members above</p>
-                  </div>
-                )}
-              </div>
-            )}
-          </div>
-
-          <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => {
-                setShowInviteModal(false)
-                setInviteEmail("")
-                setInviteRole("member")
-              }}
-            >
-              Close
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <OrganizationManagementDialog
+        open={showInviteModal}
+        onOpenChange={setShowInviteModal}
+        inviteEmail={inviteEmail}
+        onInviteEmailChange={setInviteEmail}
+        inviteRole={inviteRole}
+        onInviteRoleChange={setInviteRole}
+        isInviting={isInviting}
+        onInvite={handleInvite}
+        loadingOrgData={loadingOrgData}
+        orgMembers={orgMembers}
+        pendingInvitations={pendingInvitations}
+        userInfo={userInfo}
+        onRoleChange={handleRoleChange}
+        onClose={() => {
+          setShowInviteModal(false)
+          setInviteEmail("")
+          setInviteRole("member")
+        }}
+      />
 
       {/* Powered by Rootly AI Footer */}
       <div className="mt-12 pt-8 border-t border-gray-200 text-center">

--- a/frontend/src/app/integrations/types.ts
+++ b/frontend/src/app/integrations/types.ts
@@ -1,0 +1,193 @@
+import { z } from "zod"
+
+// Integration Mapping Types
+export interface IntegrationMapping {
+  id: number | string // Can be number or "manual_123" for manual mappings
+  source_platform: string
+  source_identifier: string
+  source_name?: string  // User's full name from analysis data
+  target_platform: string
+  target_identifier: string | null
+  mapping_successful: boolean
+  mapping_method: string | null
+  error_message: string | null
+  data_collected: boolean
+  data_points_count: number | null
+  created_at: string
+  mapping_key: string
+  // New properties for manual mappings
+  is_manual?: boolean
+  source?: 'integration' | 'manual'
+  mapping_type?: string
+  status?: string
+  confidence_score?: number
+  last_verified?: string
+}
+
+export interface MappingStatistics {
+  overall_success_rate: number
+  total_attempts: number
+  mapped_members?: number
+  members_with_data?: number
+  manual_mappings_count?: number
+  github_was_enabled?: boolean | null
+  platform_breakdown: {
+    [key: string]: {
+      total_attempts: number
+      successful: number
+      failed: number
+      success_rate: number
+    }
+  }
+}
+
+// Analysis-specific mapping statistics
+export interface AnalysisMappingStatistics {
+  total_team_members: number
+  successful_mappings: number
+  members_with_data: number
+  success_rate: number
+  failed_mappings: number
+}
+
+export interface ManualMapping {
+  id: number
+  source_platform: string
+  source_identifier: string
+  target_platform: string
+  target_identifier: string
+  mapping_type: string
+  confidence_score?: number
+  last_verified?: string
+  created_at: string
+  updated_at?: string
+  status: string
+  is_verified: boolean
+  mapping_key: string
+}
+
+export interface ManualMappingStatistics {
+  total_mappings: number
+  manual_mappings: number
+  auto_detected_mappings: number
+  verified_mappings: number
+  verification_rate: number
+  platform_breakdown: { [key: string]: { [key: string]: number } }
+  last_updated?: string
+}
+
+// Core Integration Types
+export interface Integration {
+  id: number
+  name: string
+  organization_name: string
+  total_users: number
+  total_services?: number
+  is_default: boolean
+  created_at: string
+  last_used_at: string | null
+  token_suffix: string
+  platform: "rootly" | "pagerduty"
+  permissions?: {
+    users: {
+      access: boolean
+      error: string | null
+    }
+    incidents: {
+      access: boolean
+      error: string | null
+    }
+  }
+}
+
+export interface GitHubIntegration {
+  id: number | string // Can be "beta-github" for beta integration
+  github_username: string
+  organizations: string[]
+  token_source: "oauth" | "manual" | "beta"
+  is_oauth: boolean
+  supports_refresh: boolean
+  connected_at: string
+  last_updated: string
+  is_beta?: boolean // Optional flag for beta integrations
+  token_preview?: string // Token preview for display
+}
+
+export interface SlackIntegration {
+  id: number
+  slack_user_id: string | null
+  workspace_id: string
+  workspace_name?: string
+  token_source: "oauth" | "manual"
+  is_oauth: boolean
+  supports_refresh: boolean
+  has_webhook: boolean
+  webhook_configured: boolean
+  connected_at: string
+  last_updated: string
+  total_channels?: number
+  channel_names?: string[]
+  token_preview?: string
+  webhook_preview?: string
+  connection_type?: "oauth" | "manual"
+  status?: string
+  owner_user_id?: number
+}
+
+export interface PreviewData {
+  organization_name: string
+  total_users: number
+  total_services?: number
+  suggested_name?: string
+  can_add?: boolean
+  current_user?: string
+  permissions?: {
+    users?: {
+      access: boolean
+      error?: string
+    }
+    incidents?: {
+      access: boolean
+      error?: string
+    }
+  }
+}
+
+export interface UserInfo {
+  name: string
+  email: string
+  avatar?: string
+  organization_id?: number
+  id?: number
+  role?: string
+}
+
+// Validation Schemas
+export const rootlyFormSchema = z.object({
+  rootlyToken: z.string()
+    .min(1, "Rootly API token is required")
+    .regex(/^rootly_[a-f0-9]{64}$/, "Invalid Rootly token format. Token should start with 'rootly_' followed by 64 hex characters"),
+  nickname: z.string().optional(),
+})
+
+export const pagerdutyFormSchema = z.object({
+  pagerdutyToken: z.string()
+    .min(1, "PagerDuty API token is required")
+    .regex(/^[A-Za-z0-9+_-]{20,32}$/, "Invalid PagerDuty token format. Token should be 20-32 characters long"),
+  nickname: z.string().optional(),
+})
+
+export type RootlyFormData = z.infer<typeof rootlyFormSchema>
+export type PagerDutyFormData = z.infer<typeof pagerdutyFormSchema>
+
+// Helper functions
+export const isValidRootlyToken = (token: string): boolean => {
+  return /^rootly_[a-f0-9]{64}$/.test(token)
+}
+
+export const isValidPagerDutyToken = (token: string): boolean => {
+  return /^[A-Za-z0-9+_-]{20,32}$/.test(token)
+}
+
+// API Base URL
+export const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'

--- a/frontend/src/app/integrations/utils.ts
+++ b/frontend/src/app/integrations/utils.ts
@@ -1,0 +1,111 @@
+/**
+ * Utility functions for integrations page
+ */
+
+/**
+ * Copy text to clipboard
+ */
+export async function copyToClipboard(
+  text: string,
+  setCopied: (copied: boolean) => void
+): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(text)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  } catch (err) {
+    console.error('Failed to copy: ', err)
+  }
+}
+
+/**
+ * Check if cache is stale (older than 5 minutes)
+ */
+export function isCacheStale(): boolean {
+  const timestamp = localStorage.getItem('all_integrations_timestamp')
+  if (!timestamp) return true
+
+  const age = Date.now() - parseInt(timestamp)
+  const FIVE_MINUTES = 5 * 60 * 1000
+  return age > FIVE_MINUTES
+}
+
+/**
+ * Open mapping drawer for a specific platform
+ */
+export function openMappingDrawer(
+  platform: 'github' | 'slack',
+  setMappingDrawerPlatform: (platform: 'github' | 'slack') => void,
+  setMappingDrawerOpen: (open: boolean) => void
+): void {
+  setMappingDrawerPlatform(platform)
+  setMappingDrawerOpen(true)
+}
+
+/**
+ * Handle sorting for mapping data
+ */
+export function handleSort(
+  field: 'email' | 'status' | 'data' | 'method',
+  sortField: string,
+  sortDirection: 'asc' | 'desc',
+  setSortField: React.Dispatch<React.SetStateAction<'email' | 'status' | 'data' | 'method'>>,
+  setSortDirection: React.Dispatch<React.SetStateAction<'asc' | 'desc'>>
+): void {
+  if (sortField === field) {
+    setSortDirection(sortDirection === 'asc' ? 'desc' : 'asc')
+  } else {
+    setSortField(field)
+    setSortDirection('asc')
+  }
+}
+
+/**
+ * Sort mappings by specified field and direction
+ */
+export function sortMappings(
+  mappings: any[],
+  sortField: string,
+  sortDirection: 'asc' | 'desc'
+): any[] {
+  return [...mappings].sort((a, b) => {
+    let aValue: any, bValue: any
+
+    switch (sortField) {
+      case 'email':
+        aValue = a.source_identifier.toLowerCase()
+        bValue = b.source_identifier.toLowerCase()
+        break
+      case 'status':
+        aValue = a.mapping_successful ? 1 : 0
+        bValue = b.mapping_successful ? 1 : 0
+        break
+      case 'data':
+        aValue = a.data_points_count || 0
+        bValue = b.data_points_count || 0
+        break
+      case 'method':
+        aValue = a.mapping_method || ''
+        bValue = b.mapping_method || ''
+        break
+      default:
+        return 0
+    }
+
+    if (aValue < bValue) return sortDirection === 'asc' ? -1 : 1
+    if (aValue > bValue) return sortDirection === 'asc' ? 1 : -1
+    return 0
+  })
+}
+
+/**
+ * Filter mappings to show only failed ones if requested
+ */
+export function filterMappings(
+  mappings: any[],
+  showOnlyFailed: boolean
+): any[] {
+  return showOnlyFailed
+    ? mappings.filter(m => !m.mapping_successful)
+    : mappings
+}


### PR DESCRIPTION
Reduced the monolithic integrations page from 6,504 lines to 3,860 lines (40.6% reduction) by extracting reusable components, handlers, and utilities.

**Changes:**
- Extracted 22 new modules organized into handlers/, components/, and dialogs/
- Created types.ts and utils.ts for shared code
- Improved code maintainability and reusability

**Components extracted:**
- GitHubIntegrationCard, SlackIntegrationCard
- GitHubConnectedCard, SlackConnectedCard
- RootlyIntegrationForm, PagerDutyIntegrationForm
- DeleteIntegrationDialog, GitHubDisconnectDialog, SlackDisconnectDialog
- NewMappingDialog, OrganizationManagementDialog

**Handlers extracted:**
- github-handlers.ts, slack-handlers.ts
- integration-handlers.ts, mapping-handlers.ts
- team-handlers.ts, organization-handlers.ts, ai-handlers.ts